### PR TITLE
Formatting code with clang-format

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,0 +1,18 @@
+name: clang-format Check
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+jobs:
+  formatting-check:
+    name: Formatting Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run clang-format style check for C/C++/Protobuf programs.
+        uses: jidicula/clang-format-action@v4.11.0
+        with:
+          clang-format-version: '17'

--- a/.gitignore
+++ b/.gitignore
@@ -396,3 +396,8 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+# IDEA stuff
+.idea/
+cmake-build-*
+


### PR DESCRIPTION
Implementing clang-format on project to unify code style. As per #3 LLVM code style was selected, with some changes:

* ColumnLimit: 120 (column length increased to 120 symbols)
* SortIncludes: Never (don't sort includes as this may cause compilation failures)

Additionally converted most of files from non-ASCII encoding into UTF-8 and replaced CRLF line endings.

There also first GitHub Actions pipeline to improve QoL of future Descent 3 development. Each pull request or push into main branch will trigger clang-format check.

Fixes #3.