### PR TITLE
enable CI for building

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: Descent 3 Build
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+
+      matrix:
+        os: [windows-latest]
+        build_type: [Debug, Release]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Configure CMake
+      run: cmake -B ${{github.workspace}}/build -A "Win32"
+
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build --config ${{matrix.build_type}}
+
+    - name: 'Upload Artifacts'
+      uses: actions/upload-artifact@v4
+      with:
+        name: build_${{matrix.build_type}}
+        path: ${{github.workspace}}/build/Descent3/${{matrix.build_type}}


### PR DESCRIPTION
Very simple CI config, could be used to maybe check that #13 builds properly before merging. ~That said, AngelScript fails to build as mentioned in #10 (although for some strange reason I cannot reproduce it locally!) so the build is red, but still only a single failure should be expected for that PR.~

~It's easy to remove from the CMakeLists though, but I didn't want to generate conflicts with that PR just in case.~

Update: Build is green after rebasing: https://github.com/Arcnor/Descent3/actions/runs/8712259559