### PR TITLE
Change main database registry hive to HKEY_CURRENT_USER

### DIFF
--- a/win32/windata.cpp
+++ b/win32/windata.cpp
@@ -66,7 +66,7 @@ oeWin32AppDatabase::oeWin32AppDatabase() {
 
   hCurKey = 0;
 
-  hBaseKey = (unsigned)HKEY_LOCAL_MACHINE;
+  hBaseKey = (unsigned)HKEY_CURRENT_USER;
 
   //	create outrage entertainment key
   lstrcpy(m_Basepath, "SOFTWARE\\Outrage");


### PR DESCRIPTION
This changes the main registry hive the configuration database uses on Windows to HKEY_CURRENT_USER so that the game can run without admin on newer versions of Windows. 