### PR TITLE
Use separate jobs for platforms and add dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,12 +50,14 @@ jobs:
 
     - name: Install Dependencies (macOS)
       run: |
+        brew install ninja
+        # Note this is x86_64 Homebrew
         /usr/local/bin/brew install sdl12-compat sdl2_image
         curl --output-dir /tmp -fsSLO https://github.com/XQuartz/XQuartz/releases/download/XQuartz-2.8.5/XQuartz-2.8.5.pkg
         sudo installer -pkg /tmp/XQuartz-2.8.5.pkg -target LocalSystem
 
     - name: Configure CMake (macOS)
-      run: cmake --preset mac -B ${{github.workspace}}/build
+      run: cmake --preset ${{matrix.os.preset}} -B ${{github.workspace}}/build
 
     - name: Build (macOS)
       run: cmake --build ${{github.workspace}}/build --config ${{matrix.build_type}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,35 +7,61 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build:
+  build_windows:
+    name: Windows Build
     strategy:
       fail-fast: false
 
       matrix:
-        os: [{runner: windows-latest, preset: win}, {runner: macos-latest, preset: mac}]
         build_type: [Debug, Release]
 
-    runs-on: ${{ matrix.os.runner }}
+    runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install macOS dependencies
-      if: ${{ matrix.os.preset == 'mac' }}
+    - name: Install Dependencies (Windows)
+      run: choco install sdl
+
+    - name: Configure CMake (Windows)
+      run: cmake --preset win -B ${{github.workspace}}/build
+
+    - name: Build (Windows)
+      run: cmake --build ${{github.workspace}}/build --config ${{matrix.build_type}}
+
+    - name: 'Upload Artifacts (Windows)'
+      uses: actions/upload-artifact@v4
+      with:
+        name: build_windows_${{matrix.build_type}}
+        path: ${{github.workspace}}/build/Descent3/${{matrix.build_type}}
+
+  build_macos:
+    name: macOS Build
+    strategy:
+      fail-fast: false
+
+      matrix:
+        build_type: [Debug, Release]
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Dependencies (macOS)
       run: |
-        # Note this is x86_64 Homebrew
         /usr/local/bin/brew install sdl12-compat sdl2_image
         curl --output-dir /tmp -fsSLO https://github.com/XQuartz/XQuartz/releases/download/XQuartz-2.8.5/XQuartz-2.8.5.pkg
         sudo installer -pkg /tmp/XQuartz-2.8.5.pkg -target LocalSystem
 
-    - name: Configure CMake
-      run: cmake --preset ${{matrix.os.preset}} -B ${{github.workspace}}/build
+    - name: Configure CMake (macOS)
+      run: cmake --preset mac -B ${{github.workspace}}/build
 
-    - name: Build
+    - name: Build (macOS)
       run: cmake --build ${{github.workspace}}/build --config ${{matrix.build_type}}
 
-    - name: 'Upload Artifacts'
+    - name: 'Upload Artifacts (macOS)'
       uses: actions/upload-artifact@v4
       with:
-        name: build_${{matrix.build_type}}
+        name: build_macos_${{matrix.build_type}}
         path: ${{github.workspace}}/build/Descent3/${{matrix.build_type}}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -17,6 +17,7 @@
         }
         , {
             "name": "mac"
+            , "generator": "Ninja Multi-Config"
             , "condition": {
                 "type": "equals"
                 , "lhs": "${hostSystemName}"


### PR DESCRIPTION
This commit splits the jobs in `build.yml` for easier modification and adds the SDL dependency for Windows.