### PR TITLE
Simplify link to Discord server

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ I'm so happy to see the amount of interest and participation here!
 
 Please join the Descent Developer Discord, there's an active community there already. 
 
-[https://discord.gg/GNy5CUQ](https://discord.gg/GNy5CUQ)
+<https://discord.gg/GNy5CUQ>
 
 You can expect some big commits coming soon. We'll be merging in some code that other developers did in parallel and/or after this code was archived.
 


### PR DESCRIPTION
Before this change, the README included a Discord invite link using [CommonMark’s regular link syntax][1]. When a link’s text and destination are the same, you can use an [autolink][2] to avoid repeating yourself. This change replaces the regular link with an autolink.

[1]: <https://spec.commonmark.org/0.31.2/#links>
[2]: <https://spec.commonmark.org/0.31.2/#autolinks>
