### PR TITLE
Fixes and enhancements to CMake build system

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,9 +34,7 @@ jobs:
           sudo dpkg --add-architecture i386
           sudo apt update
           sudo apt install -y --no-install-recommends \
-            make cmake g++ libsdl1.2-dev libsdl-image1.2-dev \
-            libaudio-dev libaa1-dev libdirectfb-dev \
-            libncurses-dev \
+            make cmake g++ libsdl1.2-dev libsdl-image1.2-dev libncurses-dev \
             libxext6:i386  # for ./scripts/hogutils/hogUtils-i686 binary
           mkdir ~/Descent3
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,39 +1,35 @@
-# CMake compatibility issues: don't modify this, please!
-CMAKE_MINIMUM_REQUIRED( VERSION 2.4.6 )
+CMAKE_MINIMUM_REQUIRED(VERSION 3.19)
 
-MARK_AS_ADVANCED(CMAKE_BACKWARDS_COMPATIBILITY)
 # allow more human readable "if then else" constructs
 SET( CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS TRUE )
 
+PROJECT(Descent3 VERSION 1.5.500)
 
-PROJECT(Descent3)
+SET(CMAKE_CXX_STANDARD 17)
+SET(CMAKE_CXX_STANDARD_REQUIRED ON)
+SET(CMAKE_CXX_EXTENSIONS OFF)
+SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 IF (UNIX)
-SET (D3_GAMEDIR "~/Descent3/")
-
-  SET(CMAKE_CXX_STANDARD 17)
-  SET(CMAKE_CXX_STANDARD_REQUIRED ON)
-  SET(CMAKE_CXX_EXTENSIONS OFF)
-  SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
-
+  SET (D3_GAMEDIR "~/Descent3/")
   IF (APPLE)
     SET(EXTRA_CXX_FLAGS "-Wno-address-of-temporary")
   ELSE()
     SET(EXTRA_CXX_FLAGS "-fpermissive")
   ENDIF()
 
-  SET(CMAKE_CXX_COMPILER "g++")
-  SET(CMAKE_CXX_FLAGS "-O0 -g -Wno-write-strings -Wno-multichar ${BITS} ${EXTRA_CXX_FLAGS}")
-  SET(CMAKE_C_FLAGS "-O0 -g ${BITS}")
-  SET(CMAKE_C_COMPILER "gcc")
+  SET(CMAKE_CXX_FLAGS "-Wno-write-strings -Wno-multichar ${BITS} ${EXTRA_CXX_FLAGS}")
+  SET(CMAKE_C_FLAGS "${BITS}")
 
-  FIND_PACKAGE( SDL REQUIRED )
+  FIND_PACKAGE(SDL REQUIRED)
   IF (APPLE)
     # Provide FIND_PACKAGE( SDL_image ) below with an include dir and library that work with brew-installed sdl2_image
     FIND_PATH(SDL_IMAGE_INCLUDE_DIR SDL_image.h PATH_SUFFIXES include/SDL2)
     FIND_LIBRARY(SDL_IMAGE_LIBRARY SDL2_image)
   ENDIF()
-  FIND_PACKAGE( SDL_image REQUIRED )
+  FIND_PACKAGE(SDL_image REQUIRED)
+  FIND_PACKAGE(Curses REQUIRED)
+  FIND_PACKAGE(OpenGL REQUIRED)
 MESSAGE( "SDL Include Dir is " ${SDL_INCLUDE_DIR} )
 ENDIF()
 
@@ -77,11 +73,6 @@ MESSAGE("Install will copy files to ${D3_GAMEDIR}")
 include_directories("lib" "Descent3" ${PLATFORM_INCLUDES})
 
 # file(GLOB_RECURSE INCS "*.h")
-
-# project version
-SET( ${PROJECT_NAME}_MAJOR_VERSION 1 )
-SET( ${PROJECT_NAME}_MINOR_VERSION 5 )
-SET( ${PROJECT_NAME}_PATCH_LEVEL 500 )
 
 ADD_SUBDIRECTORY (2dlib)
 ADD_SUBDIRECTORY (AudioEncode)
@@ -128,7 +119,7 @@ ADD_SUBDIRECTORY (vecmat)
 ADD_SUBDIRECTORY (libmve)
 ADD_SUBDIRECTORY (md5)
 ADD_SUBDIRECTORY (libacm)
-ADD_SUBDIRECTORY (Descent3 )
+ADD_SUBDIRECTORY (Descent3)
 
 # For now we don't need to build the scripts under windows, so we'll only include
 # the directory when building for linux/osx. In the future we may want to to fix bugs, etc.

--- a/Descent3/CMakeLists.txt
+++ b/Descent3/CMakeLists.txt
@@ -285,19 +285,17 @@ SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /SAFESEH:NO /SUBSYSTEM:WIN
 ENDIF()
 
 IF (UNIX AND NOT APPLE)
-SET (PLATFORM_LIBS linux dd_lnxsound ddvid_lnx lnxcontroller ddio_lnx ${SDL_LIBRARY} m dl GLU ncurses pulse-simple)
+SET (PLATFORM_LIBS linux dd_lnxsound ddvid_lnx lnxcontroller ddio_lnx SDL::SDL m ${CMAKE_DL_LIBS} OpenGL::GLU ${CURSES_LIBRARIES})
 SET (PLATFORM_CPPS loki_utils.c lnxmain.cpp)
 ENDIF()
 	
 IF (APPLE)
-SET (PLATFORM_LIBS linux dd_lnxsound ddvid_lnx lnxcontroller ddio_lnx ${SDL_LIBRARY} ncurses )
+SET (PLATFORM_LIBS linux dd_lnxsound ddvid_lnx lnxcontroller ddio_lnx SDL::SDL ${CURSES_LIBRARIES})
 SET (PLATFORM_CPPS loki_utils.c lnxmain.cpp SDLMain.m)
 SET(CMAKE_EXE_LINKER_FLAGS "-framework IOKit -framework Cocoa -framework OpenGL -framework Carbon")
 ENDIF()
 
 file(GLOB_RECURSE INCS "../lib/*.h")
-	
-
 
 ADD_EXECUTABLE(Descent3 ${HEADERS} ${CPPS} ${PLATFORM_CPPS} ${INCS})
 target_link_libraries(Descent3 

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -65,29 +65,23 @@ SET (SCRIPTS
 	TrainingMission
 	Y2K)
 
-SET (SCRIPTTARGETS )
-
-FOREACH( SCRIPT ${SCRIPTS})
+FOREACH(SCRIPT ${SCRIPTS})
  
-  ADD_LIBRARY(${SCRIPT} SHARED ${CPPS} "${SCRIPT}.cpp")
-  set_target_properties(${SCRIPT} PROPERTIES PREFIX "")
-  SET(SCRIPTTARGETS ${SCRIPTTARGETS} ${SCRIPT})
-    IF(UNIX)
-      GET_TARGET_PROPERTY(SCRIPT_LIB ${SCRIPT} LOCATION)
-      ADD_CUSTOM_COMMAND(
-	TARGET ${SCRIPT}
-	POST_BUILD
-	COMMAND ${CMAKE_COMMAND} -E copy ${SCRIPT_LIB} "${CMAKE_SOURCE_DIR}/scripts/data/linuxfullhog/"
-	COMMENT "Copying file ${SCRIPT_LIB} to hogfile directory..."
-	)
-      ADD_CUSTOM_COMMAND(
-	TARGET ${SCRIPT}
-	POST_BUILD
-	COMMAND ${CMAKE_COMMAND} -E copy ${SCRIPT_LIB} "${CMAKE_SOURCE_DIR}/scripts/data/linuxdemohog/"
-	)
-
-    ENDIF()
-
+	ADD_LIBRARY(${SCRIPT} SHARED ${CPPS} "${SCRIPT}.cpp")
+	set_target_properties(${SCRIPT} PROPERTIES PREFIX "")
+	IF(UNIX)
+		ADD_CUSTOM_COMMAND(
+			TARGET ${SCRIPT}
+			POST_BUILD
+			COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${SCRIPT}> "${CMAKE_SOURCE_DIR}/scripts/data/linuxfullhog/"
+			COMMENT "Copying file ${SCRIPT} to hogfile directory..."
+		)
+		ADD_CUSTOM_COMMAND(
+			TARGET ${SCRIPT}
+			POST_BUILD
+			COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${SCRIPT}> "${CMAKE_SOURCE_DIR}/scripts/data/linuxdemohog/"
+		)
+	ENDIF()
 ENDFOREACH()
 
 IF(UNIX AND NOT APPLE)
@@ -103,7 +97,7 @@ IF(UNIX AND NOT APPLE)
     COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_SOURCE_DIR}/scripts/data/linuxfullhog/d3-${HOGARCH}.hog" "${D3_GAMEDIR}"
     COMMAND ${CMAKE_COMMAND} -E remove "${CMAKE_SOURCE_DIR}/scripts/data/linuxfullhog/new.hog"
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/scripts/data/linuxfullhog/"
-    DEPENDS ${SCRIPTTARGETS}
+    DEPENDS ${SCRIPTS}
     COMMENT "Building platform specific hog."
     )
   ADD_CUSTOM_TARGET("DemoLinuxHog"
@@ -113,7 +107,7 @@ IF(UNIX AND NOT APPLE)
     COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_SOURCE_DIR}/scripts/data/linuxdemohog/new.hog" "${CMAKE_SOURCE_DIR}/scripts/data/linuxdemohog/d3-${HOGARCH}.hog"
     COMMAND ${CMAKE_COMMAND} -E remove "${CMAKE_SOURCE_DIR}/scripts/data/linuxdemohog/new.hog"
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/scripts/data/linuxdemohog/"
-    DEPENDS ${SCRIPTTARGETS}
+    DEPENDS ${SCRIPTS}
     COMMENT "Building platform specific hog."
     )
 ENDIF()


### PR DESCRIPTION
Updated compatibility level to 3.19. Set C++17 globally for all platforms. Removed hardcoded compiler and optimisation flags. Adjusted dependencies and libraries linking.

Reworked script building and hog creation.