### PR TITLE
Add inverted flight sim mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ bld/
 [Oo]bj/
 [Ll]og/
 [Ll]ogs/
+out/
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/

--- a/Descent3/ctlconfig.cpp
+++ b/Descent3/ctlconfig.cpp
@@ -1246,8 +1246,9 @@ void joystick_settings_dialog() {
   sheet->NewGroup(TXT_MOUSECONTROL, 210, y);
   msectl = sheet->AddFirstLongRadioButton(TXT_MOUSEFLIGHTSIM);
   sheet->AddLongRadioButton(TXT_MOUSELOOK);
-  *msectl = Current_pilot.mouselook_control ? 1 : 0;
-  y += 50;
+  sheet->AddLongRadioButton(TXT_MOUSEFLIGHTSIM_INVERTED);
+  *msectl = Current_pilot.mouselook_control;
+  y += 75;
   sheet->NewGroup(NULL, 210, y);
   sheet->AddLongButton(TXT_CALIBJOYSTICK, UID_JOYCFG);
   // force feedback stuff
@@ -1298,7 +1299,7 @@ void joystick_settings_dialog() {
       float val = CALC_SLIDER_FLOAT_VALUE(*mse_sens[i], 0.0f, MSE_AXIS_SENS_RANGE, CFG_AXIS_SENS_RANGE);
       Controller->set_axis_sensitivity(ctMouseAxis, i + 1, val);
     }
-    Current_pilot.mouselook_control = (*msectl) ? true : false;
+    Current_pilot.mouselook_control = *msectl;
     // force feedback stuff
     if (ff_enabled) {
       if (*ff_enabled) {

--- a/Descent3/multi_ui.cpp
+++ b/Descent3/multi_ui.cpp
@@ -1680,7 +1680,7 @@ int MultiLevelSelection(void) {
 }
 
 bool DoPlayerMouselookCheck(unsigned int flags) {
-  if (Current_pilot.mouselook_control) {
+  if (Current_pilot.mouselook_control == 1) {
     if (flags & NF_ALLOW_MLOOK) {
       return true;
     } else {

--- a/Descent3/pilot_class.cpp
+++ b/Descent3/pilot_class.cpp
@@ -1389,7 +1389,7 @@ void pilot::write_controls(CFILE *file) {
   }
   cf_WriteFloat(file, key_ramping); // 0x29- keyramping
 
-  cf_WriteByte(file, (mouselook_control ? 1 : 0)); // version 0x25 - mouselook
+  cf_WriteByte(file, mouselook_control); // version 0x25 - mouselook
 }
 
 void pilot::read_controls(CFILE *file, bool skip) {
@@ -1475,7 +1475,7 @@ void pilot::read_controls(CFILE *file, bool skip) {
   }
   if (file_version >= PFV_MOUSELOOK) {
     temp_b = cf_ReadByte(file);
-    mouselook_control = temp_b ? true : false;
+    mouselook_control = temp_b;
   }
 }
 

--- a/Descent3/pilot_class.h
+++ b/Descent3/pilot_class.h
@@ -292,7 +292,7 @@ public:
   float joy_sensitivity[N_JOY_AXIS];            // axis sensitivities
   float key_ramping;
   char read_controller;   // do we read the controller port also (beyond keyboard/mouse)
-  bool mouselook_control; // mouselook control.
+  char mouselook_control; // mouselook control.
   bool lrearview_enabled;
   bool rrearview_enabled; // are these small views enabled?
 

--- a/Descent3/stringtable.h
+++ b/Descent3/stringtable.h
@@ -912,5 +912,6 @@ char *GetStringFromTable(int index);
 #define TXI_PAGE_DOWN 898              // "Page Down"
 #endif
 
+#define TXT_MOUSEFLIGHTSIM_INVERTED TXT(1000)          // Flight Sim
 // Before adding items search for unused entries!
 #endif

--- a/scripts/data/linuxdemohog/d3.str
+++ b/scripts/data/linuxdemohog/d3.str
@@ -49,7 +49,7 @@
 
 !/!1:Used in Pilot dialog, text for deleting an existing Pilot
 !=!Delete
-!G!Löschen
+!G!Lï¿½schen
 !S!Eliminar
 !I!Elimina
 !F!Supprimer
@@ -84,22 +84,22 @@
 
 !/!6:Used in the pilot dialog, where the pilot's stats for number of kills is displayed, should not be too much longer than english version
 !=!Number of Kills:
-!G!Abschüsse:
-!S!Número de bajas:
+!G!Abschï¿½sse:
+!S!Nï¿½mero de bajas:
 !I!Numero di uccisi:
 !F!Nombre de victimes:
 
 !/!7:Used in the pilot dialog, where the pilot's stats for number of deaths is displayed, should not be too much longer than english version
 !=!Number of Deaths:
 !G!Verlorene Leben:
-!S!Número de muertes:
+!S!Nï¿½mero de muertes:
 !I!Numero di morti:
 !F!Nombre de morts:
 
 !/!8:Used in the pilot dialog, where the pilot's stats for ratio between the number of kills and deaths is displayed, should not be too much longer than english version
 !=!Kill/Deaths Ratio:
-!G!Abschüsse/Verl. Leben:
-!S!Proporción bajas/muertes:
+!G!Abschï¿½sse/Verl. Leben:
+!S!Proporciï¿½n bajas/muertes:
 !I!Rapp. uccisi/morti:
 !F!Ratio victimes/morts:
 
@@ -107,8 +107,8 @@
 !=!Difficulty:
 !G!Schwierigkeitsgrad:
 !S!Dificultad:
-!I!Difficoltà:
-!F!Difficulté:
+!I!Difficoltï¿½:
+!F!Difficultï¿½:
 
 !/!10:Used to form strings that specify level (i.e. "Level 10")
 !=!Level %d
@@ -147,10 +147,10 @@
 
 !/!15:Used in the pilot dialog if there are no pilots to be selected to be displayed
 !=!No Pilot Selected
-!G!Kein Pilot ausgewählt
+!G!Kein Pilot ausgewï¿½hlt
 !S!No se ha seleccionado un piloto
 !I!Nessun pilota selezionato
-!F!Aucun pilote sélectionné
+!F!Aucun pilote sï¿½lectionnï¿½
 
 !/!16:Used as the window title in the Pilots dialog, be careful about size, it should stay close to this size
 !=!Pilots
@@ -168,22 +168,22 @@
 
 !/!18:Error message if the user tries to exit the pilot menu without first selecting a pilot
 !=!You must create and select a pilot.
-!G!Sie müssen einen Piloten erstellen und auswählen.
+!G!Sie mï¿½ssen einen Piloten erstellen und auswï¿½hlen.
 !S!Debes crear y seleccionar un piloto.
 !I!Devi creare e selezionare un pilota.
-!F!Vous devez créer et sélectionner un pilote.
+!F!Vous devez crï¿½er et sï¿½lectionner un pilote.
 
 !/!19:Confirmation message in pilot dialog when the user wants to delete a pilot, %s must stay in the sentence somewhere, it will be replaced by the name of the pilot
 !=!Are you sure you want to delete %s?
-!G!Möchten Sie %s wirklich löschen?
-!S!¿Seguro que quieres borrar %s?
+!G!Mï¿½chten Sie %s wirklich lï¿½schen?
+!S!ï¿½Seguro que quieres borrar %s?
 !I!Sicuro di voler eliminare %s?
-!F!Etes-vous sûr de vouloir supprimer %s?
+!F!Etes-vous sï¿½r de vouloir supprimer %s?
 
 !/!20:Message box title for the message box that is displayed when the user wants to delete a pilot
 !=!Delete Confirmation
-!G!Löschen bestätigen
-!S!Confirmar eliminación
+!G!Lï¿½schen bestï¿½tigen
+!S!Confirmar eliminaciï¿½n
 !I!Conferma eliminazione
 !F!Confirmation de suppression
 
@@ -191,12 +191,12 @@
 !=!Difficulty
 !G!Schwierigkeitsgrad
 !S!Dificultad
-!I!Difficoltà
-!F!Difficulté
+!I!Difficoltï¿½
+!F!Difficultï¿½
 
 !/!22:name of the trainee difficulty level in the pilot configuration dialog
 !=!Trainee
-!G!Anfänger
+!G!Anfï¿½nger
 !S!Entrenamiento
 !I!Apprendista
 !F!debutant
@@ -210,7 +210,7 @@
 
 !/!24:name of the hotshot difficulty level in the pilot configuration dialog
 !=!Hotshot
-!G!Draufgänger
+!G!Draufgï¿½nger
 !S!Veterano
 !I!Veterano
 !F!veteran
@@ -247,24 +247,24 @@
 
 !/!29:Used in the pilot configuration dialog, hotspot label to customize the game controller
 !=!CONFIGURE CONTROLLER
-!G!STEUERGERÄT KONFIG.
+!G!STEUERGERï¿½T KONFIG.
 !S!CONFIG CONTROLADOR
-!I!CONFIGURA UNITÀ DI CONTROLLO
+!I!CONFIGURA UNITï¿½ DI CONTROLLO
 !F!CONFIGURER CONTROLEUR
 
 !/!30:Used in the pilot configuration, error message box title if there was an error copy pilot configuration
 !=!Copy Config Error
 !G!Fehler bei Konfig. kopieren
-!S!Error al copiar configuración
+!S!Error al copiar configuraciï¿½n
 !I!Errore di copia
 !F!Erreur de copie de la config.
 
 !/!31:Used in pilot configuration, if the user tries to copy the controls from the same pilot
 !=!You Can't Copy the Configuration From The Same Pilot.
-!G!Sie können die Konfiguration nicht vom selben Piloten kopieren.
-!S!No puedes copiar la configuración del mismo piloto.
+!G!Sie kï¿½nnen die Konfiguration nicht vom selben Piloten kopieren.
+!S!No puedes copiar la configuraciï¿½n del mismo piloto.
 !I!Non puoi copiare la configurazione dello stesso pilota.
-!F!Vous ne pouvez pas copier la configuration du même pilote.
+!F!Vous ne pouvez pas copier la configuration du mï¿½me pilote.
 
 !/!32:Used in the pilot dialog when you create a new pilot, message box title for entering the pilot name
 !=!Enter Pilot Name
@@ -275,7 +275,7 @@
 
 !/!33:Used in the pilot dialog when you create a new pilot, label for the edit box for entering the pilot name
 !=!Please enter a name for your pilot.
-!G!Bitte geben Sie einen Namen für Ihren Piloten ein.
+!G!Bitte geben Sie einen Namen fï¿½r Ihren Piloten ein.
 !S!Escribe un nombre para el piloto.
 !I!Immetti un nome per il pilota.
 !F!Veuillez entrer le nom du pilote.
@@ -290,23 +290,23 @@
 !/!35:Out of Drive Space?
 !=!Can't Create Pilot File (Out of Drive Space?)
 !G!Pilotendatei kann nicht erstellt werden. (Festplattenspeicher voll?)
-!S!No se puede crear archivo de piloto (¿Espacio insuficiente?)
+!S!No se puede crear archivo de piloto (ï¿½Espacio insuficiente?)
 !I!Impossibile creare il file del pilota (spazio insufficiente?)
-!F!Création fichier pilote impossible (par manque de place ?)
+!F!Crï¿½ation fichier pilote impossible (par manque de place ?)
 
 !/!36:Error message if the user tried to create a pilot without a name
 !=!You Need To Name Your Pilot.
-!G!Sie müssen Ihrem Piloten einen Namen geben.
+!G!Sie mï¿½ssen Ihrem Piloten einen Namen geben.
 !S!Tienes que dar nombre al piloto.
 !I!Devi assegnare un nome al pilota.
-!F!Vous devez donner un nom à votre pilote.
+!F!Vous devez donner un nom ï¿½ votre pilote.
 
 !/!37:Error message if the user tries to create a pilot with the same name as an exiting pilot
 !=!Pilot Already Exists. Please Rename.
 !G!Pilot existiert bereits. Bitte umbenennen.
 !S!Este piloto ya existe. Cambia el nombre.
-!I!Pilota già esistente. Cambia nome.
-!F!Ce pilote existe déjà. Changez de nom.
+!I!Pilota giï¿½ esistente. Cambia nome.
+!F!Ce pilote existe dï¿½jï¿½. Changez de nom.
 
 !/!38:Message box title for the place to choose a pilot...(to copy controls?
 !=!Choose Pilot
@@ -332,21 +332,21 @@
 !/!41: audio taunt 3 label
 !=!Audio Taunt #3
 !G!Audio-Hohn 3
-!S!Provocación nº 3
+!S!Provocaciï¿½n nï¿½ 3
 !I!Provocazione audio n. 3
 !F!Raillerie audio #3
 
 !/!42: audio taunt 4 label
 !=!Audio Taunt #4
 !G!Audio-Hohn 4
-!S!Provocación nº 4
+!S!Provocaciï¿½n nï¿½ 4
 !I!Provocazione audio n. 4
 !F!Raillerie audio #4
 
 !/!43:HUD message when not picking up energy because player is already at max
 !=!Energy Full
 !G!Energie voll
-!S!Energía al máximo
+!S!Energï¿½a al mï¿½ximo
 !I!Energia al massimo
 !F!Energie au maximum
 
@@ -355,21 +355,21 @@
 !G!Voreingestellte Steuerung 
 !S!Controles prestablecidos
 !I!Comandi preimpostati
-!F!Contrôles prédéfinis
+!F!Contrï¿½les prï¿½dï¿½finis
 
 !/!45:Message displayed for a level with no goals (in the TelCom)
 !=!There are no goals available
-!G!Es sind keine Ziele verfügbar
+!G!Es sind keine Ziele verfï¿½gbar
 !S!No hay objetivos disponibles
 !I!Nessun obiettivo disponibile
 !F!Pas d'objectifs disponibles.
 
 !/!46:In Pilot menu, dialog text asking whether they want to use preset controls
 !=!Would you like to use one of the preset configurations?
-!G!Möchten Sie eine voreingestellte Konfiguration verwenden?
-!S!¿Quieres usar una de las configuraciones prestablecidas?
+!G!Mï¿½chten Sie eine voreingestellte Konfiguration verwenden?
+!S!ï¿½Quieres usar una de las configuraciones prestablecidas?
 !I!Desideri utilizzare una delle configurazioni preimpostate?
-!F!Voulez-vous utiliser une configuration par défaut ?
+!F!Voulez-vous utiliser une configuration par dï¿½faut ?
 
 !/!47:Message in Guide-Bot menu if no Guide-Bot is available
 !=!One moment...
@@ -380,7 +380,7 @@
 
 !/!48:Used in Guide-Bot message (among other places?) as a message to press the escape key to return back to the game)
 !=!Press ESC to return
-!G!Mit ESC zurück
+!G!Mit ESC zurï¿½ck
 !S!Pulsa Esc para volver
 !I!Premi ESC per riprendere
 !F!echap pour continuer
@@ -388,7 +388,7 @@
 !/!49:Used in configuration dialog, window title for video configuration, be careful of size
 !=!Graphics
 !G!Grafik
-!S!Gráficos
+!S!Grï¿½ficos
 !I!Grafici
 !F!graphismes
 
@@ -403,15 +403,15 @@
 !=!Brightness
 !G!Helligkeit
 !S!Brillo
-!I!Luminosità
-!F!Luminosité
+!I!Luminositï¿½
+!F!Luminositï¿½
 
 !/!52:label for what type of renderer you want to use in the video configuration
 !=!Renderer
 !G!Renderer
-!S!Procesador de vídeo
+!S!Procesador de vï¿½deo
 !I!Processore video
-!F!Rendu vidéo
+!F!Rendu vidï¿½o
 
 !/!53:Direct3D renderer in video configuration
 !=!Direct3D
@@ -436,10 +436,10 @@
 
 !/!56:label for what kind of resolution you want...in video configuration
 !=!Resolution	
-!G!Auflösung	
-!S!Resolución
+!G!Auflï¿½sung	
+!S!Resoluciï¿½n
 !I!Risoluzione
-!F!Résolution
+!F!Rï¿½solution
 
 !/!57:Label for Completed goals in Telcom & post-level results
 !=!Completed
@@ -457,9 +457,9 @@
 
 !/!59:You cannot load a save game in multiplayer! (error when trying to load a multiplayer game)
 !=!You cannot load a save game in multiplayer!
-!G!Laden eines gespeicherten Spiels im Multiplayer-Modus nicht möglich!
+!G!Laden eines gespeicherten Spiels im Multiplayer-Modus nicht mï¿½glich!
 !S!No se puede cargar una partida en modo multijugador
-!I!Non puoi caricare una partita salvata in modalità multigiocatore!
+!I!Non puoi caricare una partita salvata in modalitï¿½ multigiocatore!
 !F!Vous ne pouvez pas charger une partie en mode multijoueur !
 
 !/!60:label for bilinear filtering checkbox label in video configuration
@@ -467,19 +467,19 @@
 !G!Bilineare Filterung
 !S!Filtro bilineal
 !I!Filtro bilineare
-!F!Filtrage Bilinéaire
+!F!Filtrage Bilinï¿½aire
 
 !/!61:label for MIP mapping checkbox label in video configuration
 !=!MIP Mapping
 !G!MIP Mapping
-!S!Asignación MIP
+!S!Asignaciï¿½n MIP
 !I!Mappa MIP
 !F!MIP MAPPING
 
 !/!62:label for dynamic lighting checkbox label in video configuration
 !=!Dynamic Lighting
 !G!Dyn. Ausleuchtung
-!S!Iluminación dinámica
+!S!Iluminaciï¿½n dinï¿½mica
 !I!Illuminazione dinamica
 !F!Eclairage dynamique
 
@@ -492,9 +492,9 @@
 
 !/!64:You cannot save a game in multiplayer! (error when trying to save a multiplayer game)
 !=!You cannot save a game in multiplayer!
-!G!Speichern eines Spiels im Multiplayer-Modus nicht möglich!
+!G!Speichern eines Spiels im Multiplayer-Modus nicht mï¿½glich!
 !S!No se puede guardar una partida en modo multijugador
-!I!Non puoi salvare una partita in modalità multigiocatore!
+!I!Non puoi salvare una partita in modalitï¿½ multigiocatore!
 !F!Vous ne pouvez pas sauvegarder une partie en mode multijoueur !
 
 !/!65:window title for sound configuration
@@ -506,7 +506,7 @@
 
 !/!66:label for sound volume slider in sound configuration
 !=!Sound Volume
-!G!Lautstärke
+!G!Lautstï¿½rke
 !S!Volumen del sonido
 !I!Volume del suono
 !F!Volume du son
@@ -520,7 +520,7 @@
 
 !/!68:in general configuration, label for slider for terrain Auto-leveling
 !=!Terrain Autolev
-!G!Gelände Autolev 
+!G!Gelï¿½nde Autolev 
 !S!Autoniv. terreno
 !I!Autolivellamento terreno
 !F!Stab. en surface
@@ -576,22 +576,22 @@
 
 !/!76:detail setting label for terrain detail
 !=!Terrain Detail
-!G!Geländedetails
+!G!Gelï¿½ndedetails
 !S!Detalle del terreno
 !I!Dettaglio del terreno
-!F!Détail du terrain
+!F!Dï¿½tail du terrain
 
 !/!77:detail setting label for render distance out in the terrain
 !=!Render Depth
 !G!Renderingtiefe
 !S!Profundidad de campo
-!I!Profondità di campo
+!I!Profonditï¿½ di campo
 !F!Rendu de profondeur 
 
 !/!78:detail setting label for terrain casting checkbox
 !=!Terrain Casting
-!G!Geländeprojektion
-!S!Características del terreno
+!G!Gelï¿½ndeprojektion
+!S!Caracterï¿½sticas del terreno
 !I!Caratteristiche del terreno
 !F!Projection terrain
 
@@ -620,20 +620,20 @@
 !=!Yes
 !G!Ja
 !S!Si
-!I!Sì
+!I!Sï¿½
 !F!Oui
 
 !/!83:used in control configuration dialog
 !=!Unable to initialize game control/joystick system.
-!G!Steuergerät-/Joystick- Initialisierung nicht möglich.
+!G!Steuergerï¿½t-/Joystick- Initialisierung nicht mï¿½glich.
 !S!Falla al inicializar sistema de control/joystick.
 !I!Impossibile inizializzare il sistema di controllo/joystick.
-!F!Impossible d'initialiser le système de contrôles de jeu/joystick.
+!F!Impossible d'initialiser le systï¿½me de contrï¿½les de jeu/joystick.
 
 !/!84:used in control configuration dialog
 !=!Click on 'X' or CTRL-C to clear function.
-!G!Auf 'X' klicken oder Strg-C drücken, um Funktion zu löschen.
-!S!Haz clic en "X" o pulsa Ctrl+C para desactivar función.
+!G!Auf 'X' klicken oder Strg-C drï¿½cken, um Funktion zu lï¿½schen.
+!S!Haz clic en "X" o pulsa Ctrl+C para desactivar funciï¿½n.
 !I!Fai clic su "X" o premi Ctrl+C per disattivare la funzione.
 !F!Cliquez sur 'X' ou CTRL-C pour supprimer une fonction.
 
@@ -674,24 +674,24 @@
 
 !/!90:error message is there was a problem trying to initialize the renderer
 !=!Unable to initialize renderer.
-!G!Renderer-Initialisierung nicht möglich.
-!S!Falla al inicializar procesador de vídeo.
+!G!Renderer-Initialisierung nicht mï¿½glich.
+!S!Falla al inicializar procesador de vï¿½deo.
 !I!Impossibile inizializzare il processore video
-!F!Impossible d'initialiser le processeur vidéo.
+!F!Impossible d'initialiser le processeur vidï¿½o.
 
 !/!91:error message if a font file couldn't be loaded
 !=!Unable to load font %s.
-!G!%s Font laden nicht möglich.
+!G!%s Font laden nicht mï¿½glich.
 !S!No se puede cargar fuente %s
 !I!Impossibile caricare il carattere %s.
 !F!Impossible de charger la police %s
 
 !/!92:error message if D3 ran out of memory doing a screenshot
 !=!Not enough memory for screenshot.
-!G!Nicht genug Speicherplatz für Screenshot.
+!G!Nicht genug Speicherplatz fï¿½r Screenshot.
 !S!No hay suficiente memoria para captura de pantalla.
 !I!Memoria insufficiente per cattura video.
-!F!Pas assez de mémoire pour une capture d'écran.
+!F!Pas assez de mï¿½moire pour une capture d'ï¿½cran.
 
 !/!93:HUD message for what a screenshot was saved to
 !=!Screenshot saved as '%s'.
@@ -703,7 +703,7 @@
 !/!94:HUD message in a multiplayer game if a player cheats
 !=!%s is cheating!
 !G!%s mogelt!
-!S!%s está haciendo trampa
+!S!%s estï¿½ haciendo trampa
 !I!%s sta barando!
 !F!%s est en train de tricher !
 
@@ -712,7 +712,7 @@
 !G!CPA aktiviert
 !S!Colimador activado
 !I!Collimatore attivato
-!F!collimateur activé
+!F!collimateur activï¿½
 
 !/!96:multiplayer message when joining a game
 !=!Receiving data...
@@ -724,7 +724,7 @@
 !/!97:screen message while level is loading to play
 !=!Downloading mission data...
 !G!Lade Missionsdaten...
-!S!Descargando datos de la misión...
+!S!Descargando datos de la misiï¿½n...
 !I!Scaricamento dati della missione...
 !F!Chargement des donnees de la mission...
 
@@ -747,7 +747,7 @@
 !G!Screenshot speichern
 !S!Guardar captura de pantalla.
 !I!Salva immagine video
-!F!Sauvegarder une capture d'écran
+!F!Sauvegarder une capture d'ï¿½cran
 
 !/!101:label in help screen for key..most likely shouldn't change
 !=!F3
@@ -772,8 +772,8 @@
 
 !/!104:in help screen, label
 !=!Go To Options Menu
-!G!Zum Optionsmenü
-!S!Ir a menú de opciones
+!G!Zum Optionsmenï¿½
+!S!Ir a menï¿½ de opciones
 !I!Passa al menu delle opzioni
 !F!Atteindre Menu Options
 
@@ -800,10 +800,10 @@
 
 !/!108:in help screen, label
 !=!Increase/Decrease Screen Size
-!G!Bild vergrössern/verkleinern
-!S!Aumentar/Reducir tamaño de pantalla
+!G!Bild vergrï¿½ssern/verkleinern
+!S!Aumentar/Reducir tamaï¿½o de pantalla
 !I!Aumenta/riduci dimensioni schermo
-!F!Augmenter/réduire la taille de l'écran
+!F!Augmenter/rï¿½duire la taille de l'ï¿½cran
 
 !/!109:Pause
 !=!Pause
@@ -822,21 +822,21 @@
 !/!111:label in help screen for key..most likely shouldn't change
 !=!SHIFT-F1
 !G!SHIFT-F1
-!S!Mayús+F1
+!S!Mayï¿½s+F1
 !I!Maiusc+F1
 !F!Maj.+F1
 
 !/!112:label in help screen for key..most likely shouldn't change
 !=!SHIFT-F2
 !G!SHIFT-F2
-!S!Mayús+F2
+!S!Mayï¿½s+F2
 !I!Maiusc+F2
 !F!Maj.-F2
 
 !/!113:label in help screen for key..most likely shouldn't change
 !=!SHIFT-F3
 !G!SHIFT-F3
-!S!Mayús+F3
+!S!Mayï¿½s+F3
 !I!Maiusc+F3
 !F!Maj.-F3
 
@@ -845,21 +845,21 @@
 !G!Ansicht im linken Fenster wechseln
 !S!Cambiar vista de video izquierda
 !I!Passa alla vista della finestra sinistra
-!F!Afficher Fenêtre Gauche
+!F!Afficher Fenï¿½tre Gauche
 
 !/!115:Used in config dialog when adjusting settings on a joystick or mouse.
 !=!Joystick-Mouse Settings
 !G!Joystick-Maus-Einstellungen
-!S!Configuración de ratón/joystick
+!S!Configuraciï¿½n de ratï¿½n/joystick
 !I!Impostazioni joystick-mouse
-!F!paramètres joystick/souris
+!F!paramï¿½tres joystick/souris
 
 !/!116:in help screen, label
 !=!Cycle Right Window View
 !G!Ansicht im rechten Fenster wechseln
 !S!Cambiar vista de video derecha
 !I!Passa alla vista della finestra destra
-!F!afficher fenêtre droite
+!F!afficher fenï¿½tre droite
 
 !/!117:HUD message format for multiplayer games when a player says a message, make sure %s's stay and line length doesn't go much longer
 !=!%s says: %s
@@ -878,9 +878,9 @@
 !/!119:Keyboard settings via config menu in dialog opened with adjust settings is pressed.
 !=!Keyboard Settings
 !G!Tastatur-Einstellungen
-!S!Configuración de teclado
+!S!Configuraciï¿½n de teclado
 !I!Impostazioni della tastiera
-!F!Paramètres Clavier
+!F!Paramï¿½tres Clavier
 
 !/!120:HUD label for inventory item
 !=!INV
@@ -901,14 +901,14 @@
 !G!%s inaktiv
 !S!%s desactivado
 !I!%s disattivato
-!F!%s-désactivé
+!F!%s-dï¿½sactivï¿½
 
 !/!123:game state message when you are entering the game
 !=!Downloading data...
 !G!Lade Daten...
 !S!Descargando datos...
 !I!Scaricamento dati...
-!F!Chargement des données...
+!F!Chargement des donnï¿½es...
 
 !/!124:error message when loading the game
 !=!Could not read table files.
@@ -922,21 +922,21 @@
 !G!Analysiere Daten...
 !S!Analizando datos...
 !I!Analisi dei dati...
-!F!Analyse des données...
+!F!Analyse des donnï¿½es...
 
 !/!126:error message when loading a level
 !=!Cannot load level: Version number too new.
 !G!Level kann nicht geladen werden: Version zu neu.
-!S!No se puede cargar el nivel: Versión demasiado reciente.
+!S!No se puede cargar el nivel: Versiï¿½n demasiado reciente.
 !I!Impossibile caricare il livello: numero di versione troppo recente.
-!F!Chargement du niveau impossible : numéro de version trop récent.
+!F!Chargement du niveau impossible : numï¿½ro de version trop rï¿½cent.
 
 !/!127:Used in configuration menus for help for keyboard/joystick config.
 !=!Select slot to configure.
-!G!Wählen Sie die zu konfigurierende Funktion aus.
+!G!Wï¿½hlen Sie die zu konfigurierende Funktion aus.
 !S!Selecciona ranura para configurar.
 !I!Seleziona lo slot da configurare.
-!F!Sélectionnez la commande à configurer.
+!F!Sï¿½lectionnez la commande ï¿½ configurer.
 
 !/!128:Main menu option label
 !=!New Game
@@ -976,7 +976,7 @@
 !/!133:Load Mission
 !=!Load Mission
 !G!Mission laden
-!S!Cargar misión
+!S!Cargar misiï¿½n
 !I!Carica missione
 !F!Charger mission
 
@@ -990,7 +990,7 @@
 !/!135:Failed to load mission.
 !=!Could not load mission
 !G!Mission konnte nicht geladen werden
-!S!No se ha podido cargar misión
+!S!No se ha podido cargar misiï¿½n
 !I!Impossibile caricare la missione
 !F!Echec du chargement de la mission
 
@@ -1004,14 +1004,14 @@
 !/!137:hotspot label in Options menu
 !=!Joy/Mouse
 !G!Joy/Maus
-!S!Joy/ratón
+!S!Joy/ratï¿½n
 !I!Joystick/Mouse
 !F!Joy/Souris
 
 !/!138:hotspot label in Options menu
 !=!Video
 !G!Grafik
-!S!Vídeo
+!S!Vï¿½deo
 !I!Video
 !F!Video
 
@@ -1052,7 +1052,7 @@
 
 !/!144:error message if there is a problem loading a level
 !=!Unable to load level file %s.
-!G!Datei %s laden nicht möglich.
+!G!Datei %s laden nicht mï¿½glich.
 !S!No se puede cargar archivo de nivel %s.
 !I!Impossibile caricare il file del livello %s.
 !F!Impossible de charger fichier du niveau %s.
@@ -1076,25 +1076,25 @@
 !G!%s hat das Spiel verlassen
 !S!%s ha salido del juego
 !I!%s ha abbandonato la partita
-!F!%s a quitté la partie.
+!F!%s a quittï¿½ la partie.
 
 !/!148:message when the server quits the game
 !=!The server has quit the game.
 !G!Der Server hat das Spiel beendet.
 !S!El servidor ha finalizado el juego.
 !I!Il server ha terminato la partita.
-!F!Le serveur a quitté la partie.
+!F!Le serveur a quittï¿½ la partie.
 
 !/!149:multiplayer HUD message when a player disconnects
 !=!%s disconnected
 !G!%s Verbindung abgebrochen
 !S!%s se ha desconectado.
-!I!%s si è scollegato.
-!F!%s s'est déconnecté.
+!I!%s si ï¿½ scollegato.
+!F!%s s'est dï¿½connectï¿½.
 
 !/!150:error message when loading a level in a multiplayer level
 !=!Levels don't match.
-!G!Levels stimmen nicht überein.
+!G!Levels stimmen nicht ï¿½berein.
 !S!Los niveles no coinciden.
 !I!I livelli non corrispondono.
 !F!Niveaux non concordants.
@@ -1104,11 +1104,11 @@
 !G!Vom Server getrennt.
 !S!Desconectado del servidor.
 !I!Scollegato dal server.
-!F!Déconnexion au serveur.
+!F!Dï¿½connexion au serveur.
 
 !/!152:general error message when trying to connect to a server
 !=!Can't connect. Reason: %s
-!G!Verbindung nicht möglich. Grund: %s
+!G!Verbindung nicht mï¿½glich. Grund: %s
 !S!No se puede conectar. Causa: %s
 !I!Collegamento impossibile. Causa: %s
 !F!Connexion impossible. Raison: %s
@@ -1118,7 +1118,7 @@
 !G!Keine Antwort vom Server.
 !S!No hay respuesta del servidor.
 !I!Nessuna risposta dal server.
-!F!Pas de réponse du serveur.
+!F!Pas de rï¿½ponse du serveur.
 
 !/!154:Waiting for server...		
 !=!Waiting for server...
@@ -1130,7 +1130,7 @@
 !/!155:error message trying to get info from the server
 !=!No level info from server.
 !G!Keine Levelinfo vom Server.
-!S!Servidor no proporciona información de nivel.
+!S!Servidor no proporciona informaciï¿½n de nivel.
 !I!Nessuna informazione di livello dal server.
 !F!Aucune info venant du serveur.
 
@@ -1143,9 +1143,9 @@
 
 !/!157:Machine is not server
 !=!Machine is not server.
-!G!Gerät ist nicht Server.
+!G!Gerï¿½t ist nicht Server.
 !S!No es un servidor.
-!I!Il computer non è un server.
+!I!Il computer non ï¿½ un server.
 !F!La machine n'est pas un serveur.
 
 !/!158:error message if you try to connect to a server
@@ -1153,20 +1153,20 @@
 !G!Sie sind gesperrt!
 !S!Te han vetado
 !I!Sei escluso!
-!F!Vous êtes banni !
+!F!Vous ï¿½tes banni !
 
 !/!159:error message if you try to connect to a server
 !=!Not enough start positions.
 !G!Nicht genug Startpositionen.
 !S!No hay suficientes posiciones de comienzo.
 !I!Posizioni di partenza insufficienti.
-!F!Pas assez de positions de départ.
+!F!Pas assez de positions de dï¿½part.
 
 !/!160:error message if you try to connect to a server
 !=!Server is full.
 !G!Server ist voll.
-!S!El servidor está lleno.
-!I!Il server è completo.
+!S!El servidor estï¿½ lleno.
+!I!Il server ï¿½ completo.
 !F!Le serveur est complet.
 
 !/!161:Multiplayer						
@@ -1178,8 +1178,8 @@
 
 !/!162:Choose Connection Type
 !=!Choose Connection Type
-!G!Verbindungsart auswählen
-!S!Elige tipo de conexión
+!G!Verbindungsart auswï¿½hlen
+!S!Elige tipo de conexiï¿½n
 !I!Scegli il tipo di collegamento
 !F!Choisissez un type de connexion
 
@@ -1187,7 +1187,7 @@
 !=!No Multiplayer Files Found
 !G!Keine Multiplayerdatein gefunden
 !S!No se encuentran archivos multijugador
-!I!Non è stato trovato alcun file multigiocatore
+!I!Non ï¿½ stato trovato alcun file multigiocatore
 !F!Fichiers multijoueurs introuvables
 
 !/!164:Used in options menu for weapon selection precedence
@@ -1199,7 +1199,7 @@
 
 !/!165:Press space bar to continue...
 !=!Press space bar to continue...
-!G!Zum Fortsetzen Leertaste drücken...
+!G!Zum Fortsetzen Leertaste drï¿½cken...
 !S!Pulsa barra espaciadora para continuar...
 !I!Premi la barra spazio per continuare...
 !F!Appuyez sur la barre d'espace pour continuer...
@@ -1214,9 +1214,9 @@
 !/!167:skill rating for post level result
 !=!Feeble
 !G!Lahm
-!S!Débil
+!S!Dï¿½bil
 !I!Debole
-!F!Médiocre
+!F!Mï¿½diocre
 
 !/!168:skill rating for post level result
 !=!Poor
@@ -1249,9 +1249,9 @@
 !/!172:skill rating for post level result
 !=!Supreme
 !G!Super
-!S!Magnífico
+!S!Magnï¿½fico
 !I!Magnifico
-!F!Suprême
+!F!Suprï¿½me
 
 !/!173:Telcom message while it is loading up a briefing
 !=!Please wait... Initializing
@@ -1262,15 +1262,15 @@
 
 !/!174:TelCom Main Menu text
 !=!Main Menu
-!G!Hauptmenü
-!S!Menú principal
+!G!Hauptmenï¿½
+!S!Menï¿½ principal
 !I!Menu principale
 !F!menu telcom
 
 !/!175:TelCom Main Menu Briefings option
 !=!Briefings
 !G!Anweisungen
-!S!Órdenes
+!S!ï¿½rdenes
 !I!Istruzioni preliminari
 !F!briefings
 
@@ -1285,7 +1285,7 @@
 !/!177:Laser		
 !=!Laser
 !G!Laser
-!S!Láser
+!S!Lï¿½ser
 !I!Laser
 !F!Laser
 
@@ -1313,14 +1313,14 @@
 !/!181:Fusion
 !=!Fusion
 !G!Fusion
-!S!Fusión
+!S!Fusiï¿½n
 !I!Fusione
 !F!Fusion
 
 !/!182:Super Laser
 !=!Super Laser
 !G!Superlaser
-!S!Superláser
+!S!Superlï¿½ser
 !I!Super Laser 
 !F!Super Laser
 
@@ -1341,7 +1341,7 @@
 !/!185:EMD Gun
 !=!EMD Gun
 !G!EMD-Kanone
-!S!Cañón IEM
+!S!Caï¿½ï¿½n IEM
 !I!Cannone EMD
 !F!Canon DEM
 
@@ -1350,11 +1350,11 @@
 !G!Omega
 !S!Omega
 !I!Omega
-!F!Oméga
+!F!Omï¿½ga
 
 !/!187:Concussion
 !=!Concussion
-!G!Erschütterung
+!G!Erschï¿½tterung
 !S!Cohete S-1
 !I!Esplosivo
 !F!Explosif
@@ -1364,7 +1364,7 @@
 !G!Zielpeil
 !S!Buscador
 !I!Autoguidato
-!F!Autoguidé
+!F!Autoguidï¿½
 
 !/!189:Impact Mortar
 !=!Impact Mortar
@@ -1385,7 +1385,7 @@
 !G!Mega
 !S!Mega
 !I!Mega
-!F!Méga
+!F!Mï¿½ga
 
 !/!192:Frag
 !=!Frag
@@ -1399,7 +1399,7 @@
 !G!Fernlenk
 !S!Guiado
 !I!Teleguidato
-!F!Guidé
+!F!Guidï¿½
 
 !/!194:Napalm Rocket
 !=!Napalm Rocket
@@ -1411,14 +1411,14 @@
 !/!195:Cyclone
 !=!Cyclone
 !G!Zyklon
-!S!Ciclón
+!S!Ciclï¿½n
 !I!Ciclone
 !F!Cyclone
 
 !/!196:Black Shark
 !=!Black Shark
 !G!Black Shark
-!S!Tiburón negro
+!S!Tiburï¿½n negro
 !I!Squalo nero
 !F!Requin Noir
 
@@ -1427,12 +1427,12 @@
 !G!Gelbes Leuchtgeschoss
 !S!Bengala
 !I!Bengala giallo
-!F!Fusée jaune
+!F!Fusï¿½e jaune
 
 !/!198:Laser Cockpit Pt. 1
 !=!Laser
 !G!Laser
-!S!Láser
+!S!Lï¿½ser
 !I!Laser
 !F!Laser
 
@@ -1488,7 +1488,7 @@
 !/!206:Fusion Cockpit Pt. 1
 !=!Fusion
 !G!Fusion
-!S!Fusión
+!S!Fusiï¿½n
 !I!Fusione
 !F!Fusion
 
@@ -1502,14 +1502,14 @@
 !/!208:Superlaser Cockpit Pt. 1
 !=!Super
 !G!Super-
-!S!Súper
+!S!Sï¿½per
 !I!Super
 !F!Super
 
 !/!209:Superlaser Cockpit Pt. 2
 !=!Laser
 !G!laser
-!S!Láser
+!S!Lï¿½ser
 !I!Laser
 !F!laser
 
@@ -1518,7 +1518,7 @@
 !G!Masse-
 !S!Lanza
 !I!Lancia
-!F!Canon à
+!F!Canon ï¿½
 
 !/!211:Mass Driver Cockpit Pt. 2
 !=!Driver
@@ -1560,7 +1560,7 @@
 !G!Omega
 !S!Omega
 !I!Omega
-!F!Oméga
+!F!Omï¿½ga
 
 !/!217:Omega Cockpit Pt. 2
 !=!
@@ -1571,7 +1571,7 @@
 
 !/!218:Concussion Cockpit Pt. 1
 !=!Concussn
-!G!Erschütt.
+!G!Erschï¿½tt.
 !S!Cohete S-1
 !I!Esplosivo
 !F!Explosif
@@ -1588,7 +1588,7 @@
 !G!Zielpeil
 !S!Buscador
 !I!Autoguidato
-!F!Autoguidé
+!F!Autoguidï¿½
 
 !/!221:Homing Cockpit Pt. 2
 !=!
@@ -1630,7 +1630,7 @@
 !G!Mega
 !S!Mega
 !I!Mega
-!F!Méga
+!F!Mï¿½ga
 
 !/!227:Mega Cockpit Pt. 2
 !=!
@@ -1658,7 +1658,7 @@
 !G!Fernlenk
 !S!Guiado
 !I!Teleguidato
-!F!Guidé
+!F!Guidï¿½
 
 !/!231:Guided Cockpit Pt. 2
 !=!
@@ -1684,7 +1684,7 @@
 !/!234:Cyclone Cockpit Pt. 1
 !=!Cyclone
 !G!Zyklon
-!S!Ciclón
+!S!Ciclï¿½n
 !I!Ciclone
 !F!Cyclone
 
@@ -1698,7 +1698,7 @@
 !/!236:Black Cockpit Shark Pt. 1
 !=!Black
 !G!Black
-!S!Tiburón
+!S!Tiburï¿½n
 !I!Squalo
 !F!Requin 
 
@@ -1714,7 +1714,7 @@
 !G!Leucht-
 !S!Bengala
 !I!Bengala
-!F!Fusée
+!F!Fusï¿½e
 
 !/!239:Yellow Flare Cockpit Pt. 2
 !=!Flare
@@ -1726,7 +1726,7 @@
 !/!------------------------ HUD Messages for weapon select --------------------------------
 !/!240:A weapon is not available when the user tries to select it
 !=!Weapon not available
-!G!Waffe nicht verfügbar
+!G!Waffe nicht verfï¿½gbar
 !S!Arma no disponible
 !I!Arma non disponibile
 !F!Arme non disponible
@@ -1740,7 +1740,7 @@
 
 !/!242:%s selected. HUD messsage for a weapon selected. %s is the weapon name.
 !=!%s selected
-!G!%s ausgewählt
+!G!%s ausgewï¿½hlt
 !S!%s seleccionado.
 !I!%s selezionato.
 !F!%s
@@ -1748,20 +1748,20 @@
 !/!243:Not enough energy available to fire this weapon
 !=!Not enough energy to fire weapon
 !G!Energie reicht nicht, um Waffe abzufeuern
-!S!No hay suficiente energía para usar arma
+!S!No hay suficiente energï¿½a para usar arma
 !I!Energia insufficiente per utilizzare l'arma
-!F!Pas assez d'énergie pour tirer
+!F!Pas assez d'ï¿½nergie pour tirer
 
 !/!244:Not enough ammo available to fire this weapon
 !=!Not enough ammo to fire weapon
 !G!Nicht genug Munition, um Waffe abzufeuern
-!S!No hay suficiente munición para usar arma
+!S!No hay suficiente municiï¿½n para usar arma
 !I!Munizioni insufficienti per utilizzare l'arma
 !F!Pas assez de munitions pour tirer
 
 !/!245:Not enough secondaries available
 !=!Weapon not available
-!G!Waffe nicht vefügbar
+!G!Waffe nicht vefï¿½gbar
 !S!Arma no disponible
 !I!Arma non disponibile
 !F!Arme non disponible
@@ -1769,9 +1769,9 @@
 !/!246:Not enough energy available to fire flare
 !=!Not enough energy to fire flare
 !G!Energie reicht nicht, um Leuchtgeschoss abzufeuern 
-!S!No hay suficiente energía para usar bengala
+!S!No hay suficiente energï¿½a para usar bengala
 !I!Energia insufficiente per lanciare il bengala
-!F!Pas assez d'énergie pour tirer une fusée.
+!F!Pas assez d'ï¿½nergie pour tirer une fusï¿½e.
 
 !/!-----------------------------------------------------------------------------------------
 
@@ -1780,7 +1780,7 @@
 !G!%s Verbindung abgebrochen!
 !S!%s ha desconectado
 !I!%s scollegato!
-!F!%s déconnecté !
+!F!%s dï¿½connectï¿½ !
 
 !/!--------------------------- Text Labels for Post Level Results ----------------------------
 !/!248:Accuracy rating:
@@ -1788,7 +1788,7 @@
 !G!Treffgenauigkeitsbewertung:
 !S!Tasa de exactitud:
 !I!Classificazione precisione:
-!F!Taux de précision :
+!F!Taux de prï¿½cision :
 
 !/!249:Shield rating:
 !=!Shield rating:
@@ -1800,35 +1800,35 @@
 !/!250:Energy rating
 !=!Energy rating:
 !G!Energiebewertung:
-!S!Tasa de energía:
+!S!Tasa de energï¿½a:
 !I!Classificazione energia:
-!F!Taux d'énergie :
+!F!Taux d'ï¿½nergie :
 
 !/!251:Robots destroyed
 !=!Robots destroyed:
-!G!Zerstörte Roboter:
+!G!Zerstï¿½rte Roboter:
 !S!Enemigos eliminados:
 !I!Nemici eliminati:
-!F!Robots détruits:
+!F!Robots dï¿½truits:
 
 !/!252:Mine explored:
 !=!Mine explored:
 !G!Mineneerforschung:
 !S!Mina explorada:
 !I!Miniera esplorata:
-!F!Mine explorée :
+!F!Mine explorï¿½e :
 
 !/!253:Time played:
 !=!Time played:
 !G!Spielzeit:
 !S!Tiempo jugado:
 !I!Tempo di gioco:
-!F!Durée de la partie :
+!F!Durï¿½e de la partie :
 
 !/!254:Times restored: (Post level results)
 !=!Times restored:
 !G!Wiedereinstieg:
-!S!Veces de restauración:
+!S!Veces de restauraciï¿½n:
 !I!Numero di ripristini:
 !F!Nombre de chargements :
 
@@ -1842,9 +1842,9 @@
 !/!256:Success
 !=!Success
 !G!Erfolgreich
-!S!Éxito
+!S!ï¿½xito
 !I!Successo
-!F!Succès
+!F!Succï¿½s
 
 !/!257:Failed
 !=!Failed
@@ -1857,7 +1857,7 @@
 
 !/!258:Label in Controller configuration
 !=!fire primary
-!G!Primäre feuern
+!G!Primï¿½re feuern
 !S!disparar prin
 !I!fuoco principale
 !F!tir primaire
@@ -1871,45 +1871,45 @@
 
 !/!260:Label in Controller configuration
 !=!forward
-!G!Vorwärts
+!G!Vorwï¿½rts
 !S!acelerar
 !I!avanti
 !F!avant
 
 !/!261:Label in Controller configuration
 !=!reverse
-!G!Rückwärts
+!G!Rï¿½ckwï¿½rts
 !S!reversa
 !I!indietro
-!F!arrière
+!F!arriï¿½re
 
 !/!262:Label in Controller configuration
 !=!slide horiz
 !G!Horiz. gleiten
 !S!desl horiz
 !I!scivola orizzontale
-!F!glissée horiz.
+!F!glissï¿½e horiz.
 
 !/!263:Label in Controller configuration
 !=!slide left
 !G!Links gleiten
 !S!desl izqda
 !I!scivola a sinistra
-!F!glissée à gauche
+!F!glissï¿½e ï¿½ gauche
 
 !/!264:Label in Controller configuration
 !=!slide right
 !G!Rechts gleiten
 !S!desl dcha
 !I!scivola a destra
-!F!glissée à droite
+!F!glissï¿½e ï¿½ droite
 
 !/!265:Label in Controller configuration
 !=!slide vertical
 !G!Vertik. gleiten
 !S!desl vert
 !I!scivola verticale
-!F!glissée vertic.
+!F!glissï¿½e vertic.
 
 !/!266:Label in Controller configuration
 !=!slide up
@@ -1958,28 +1958,28 @@
 !G!Links drehen
 !S!torcer izquda
 !I!vira a sinistra
-!F!virer à gauche
+!F!virer ï¿½ gauche
 
 !/!273:Label in Controller configuration
 !=!turn right
 !G!Rechts drehen
 !S!torcer decha
 !I!vira a destra
-!F!virer à droite
+!F!virer ï¿½ droite
 
 !/!274:Label in Controller configuration
 !=!fire flare
 !G!Leuchtg. feuern
 !S!lanzar bengala
 !I!spara bengala
-!F!tir fusée
+!F!tir fusï¿½e
 
 !/!275:Label in Controller configuration
 !=!toggle slide
 !G!Gleiten festst.
 !S!conmutar desl
 !I!commuta sciv
-!F!basc. glissée
+!F!basc. glissï¿½e
 
 !/!276:Label in Controller configuration
 !=!toggle bank
@@ -1991,14 +1991,14 @@
 !/!277:Label in Controller configuration
 !=!heading
 !G!Flugrichtung
-!S!dirección
+!S!direcciï¿½n
 !I!direzione
 !F!cap
 
 !/!278:Label in Controller configuration
 !=!pitch
-!G!Längsneigung
-!S!inclinación
+!G!Lï¿½ngsneigung
+!S!inclinaciï¿½n
 !I!inclinazione
 !F!tangage
 
@@ -2007,14 +2007,14 @@
 !G!Schubantrieb
 !S!acelerador
 !I!accelera
-!F!accélération
+!F!accï¿½lï¿½ration
 
 !/!280:Label in Controller configuration
 !=!throttle
 !G!Schubregelung
 !S!acelerador
 !I!accelera
-!F!accélération
+!F!accï¿½lï¿½ration
 
 !/!281:Label in Controller configuration
 !=!bank
@@ -2055,8 +2055,8 @@
 
 !/!286:music volume slider label in sound config
 !=!Music Volume
-!G!Musiklautstärke
-!S!Volumen música
+!G!Musiklautstï¿½rke
+!S!Volumen mï¿½sica
 !I!Volume musica
 !F!Volume de la musique
 
@@ -2097,10 +2097,10 @@
 
 !/!292:sound quality slider label in sound config
 !=!Sound Quality
-!G!Soundqualität
+!G!Soundqualitï¿½t
 !S!Calidad sonido
-!I!Qualità del suono
-!F!Qualité Sonore
+!I!Qualitï¿½ del suono
+!F!Qualitï¿½ Sonore
 
 !/!293:sound quality
 !=!High
@@ -2125,8 +2125,8 @@
 
 !/!296:Used in key/joystick config help
 !=!Joystick Handle, mouse, throttle
-!G!Steuerknüppel, Maus, Schubregler
-!S!palanca del joystick, ratón, acelerar
+!G!Steuerknï¿½ppel, Maus, Schubregler
+!S!palanca del joystick, ratï¿½n, acelerar
 !I!Impugnatura del joystick, mouse, acceleratore
 !F!joystick, la souris ou la manette.
  
@@ -2140,7 +2140,7 @@
 !/!298:graphical HUD representation
 !=!Graphic
 !G!Grafik
-!S!Gráfico
+!S!Grï¿½fico
 !I!Grafico
 !F!Graph.
 
@@ -2154,14 +2154,14 @@
 !/!300:HUD customization label
 !=!Shield/Energy
 !G!Schutzschild/Energie
-!S!Escudo/energía
+!S!Escudo/energï¿½a
 !I!Scudo/energia
 !F!Bouclier/Energie
 
 !/!301:HUD customization label
 !=!Weapon Layout
 !G!Waffenaufstellung
-!S!Disposición de armas
+!S!Disposiciï¿½n de armas
 !I!Disposizione dell'arma
 !F!Affichage des armes
 
@@ -2182,7 +2182,7 @@
 !/!304:HUD customization label
 !=!Mission Status
 !G!Missionsstatus
-!S!Estado de misión
+!S!Estado de misiï¿½n
 !I!Stato della missione
 !F!Statut de la mission
 
@@ -2196,28 +2196,28 @@
 !/!306:Help in key/joystick config dialog
 !=!Joystick, mouse buttons or hat
 !G!Joystick, Maustasten oder POV-Knopf
-!S!Joystick, botones del ratón o hat
+!S!Joystick, botones del ratï¿½n o hat
 !I!Joystick, pulsanti del mouse o hat
 !F!Joystick, souris ou chapeau
 
 !/!307:specular mapping setting in detail settings
 !=!Specular mapping
 !G!Reflexionen
-!S!Asignación invertida
+!S!Asignaciï¿½n invertida
 !I!Mappatura speculare
-!F!Mapping spéculaire
+!F!Mapping spï¿½culaire
 
 !/!308:key/joystick config dialog binding 1.
 !=!Binding 1: %s
 !G!Zuweisung 1: %s
-!S!Vínculo 1: %s
+!S!Vï¿½nculo 1: %s
 !I!Legatura 1: %s
 !F!Liaison 1: %s
 
 !/!309:key/joystick config dialog binding 2.
 !=!Binding 2: %s
 !G!Zuweisung 2: %s
-!S!Vínculo 2: %s 
+!S!Vï¿½nculo 2: %s 
 !I!Legatura 2: %s
 !F!Liaison 2: %s
 
@@ -2239,7 +2239,7 @@
 !=!ANTIGRAV FAIL
 !G!ANTIGRAVITATION VERSAGT
 !S!FALLO ANTIGRAVEDAD
-!I!GUASTO ANTIGRAVITÀ
+!I!GUASTO ANTIGRAVITï¿½
 !F!DEFAUT ANTIGRAVITE
 
 !/!313:HUD message if a missile has a lock on you
@@ -2287,14 +2287,14 @@
 !/!319: Used in Telcom Ship selection
 !=!Ship Select
 !G!Schiffsauswahl
-!S!Configuración de nave
+!S!Configuraciï¿½n de nave
 !I!Configurazione nave multigiocatore
 !F!selection du vaisseau
 
 !/!320:Used in Pilot ship customization dialog
 !=!Ship Display
 !G!Schiff
-!S!Presentación de nave
+!S!Presentaciï¿½n de nave
 !I!Presentazione di nave
 !F!vaisseau
 
@@ -2317,20 +2317,20 @@
 !G!Auswahl
 !S!Elegir
 !I!Scegli
-!F!Sélection
+!F!Sï¿½lection
 
 !/!324:Used in Pilot ship customization dialog
 !=!Success
 !G!Erfolg
-!S!Éxito
+!S!ï¿½xito
 !I!Successo
-!F!Succès
+!F!Succï¿½s
 
 !/!325:Used in Pilot ship customization dialog
 !=!There was an error importing
 !G!Fehler beim Importieren
 !S!Ha ocurrido un error al importar
-!I!Si è verificato un errore durante l'importazione
+!I!Si ï¿½ verificato un errore durante l'importazione
 !F!Une erreur s'est produite durant l'importation
 
 !/!326:Used in Pilot ship customization dialog
@@ -2338,7 +2338,7 @@
 !G!Animierte Grafik erfolgreich importiert.
 !S!Mapa de bits animado importado correctamente.
 !I!Bitmap animata importata con successo.
-!F!Importation du bitmap animé réussie.
+!F!Importation du bitmap animï¿½ rï¿½ussie.
 
 !/!327:Used in Pilot ship customization dialog
 !=!Custom Logo
@@ -2350,20 +2350,20 @@
 !/!328:Used in Pilot ship customization dialog
 !=!SHIP CONFIGURATION
 !G!SCHIFFSKONFIGURATION
-!S!CONFIGURACIÓN DE NAVE
+!S!CONFIGURACIï¿½N DE NAVE
 !I!CONFIGURAZIONE DELLA NAVE
 !F!CONFIGURER VAISSEAU
 
 !/!329:Used in file dialog
 !=!Up To Parent Directory
-!G!übergeordnetes Verz.
+!G!ï¿½bergeordnetes Verz.
 !S!Subir al directorio superior
 !I!Vai a directory superiore
-!F!Vers répertoire parent
+!F!Vers rï¿½pertoire parent
 
 !/!330:Used in file dialog
 !=!You Must Select A Filename.
-!G!Bitte Dateinamen auswählen.
+!G!Bitte Dateinamen auswï¿½hlen.
 !S!Debes seleccionar un nombre de archivo.
 !I!Selezionare un nome di file.
 !F!Vous devez choisir un nom de fichier.
@@ -2377,28 +2377,28 @@
 
 !/!332:Used in file dialog
 !=!Invalid Path/Directory
-!G!Ungültiger Pfad/Verzeichnis
-!S!Ruta o directorio no válido
+!G!Ungï¿½ltiger Pfad/Verzeichnis
+!S!Ruta o directorio no vï¿½lido
 !I!Percorso o directory non validi
-!F!Chemin/répertoire incorrect
+!F!Chemin/rï¿½pertoire incorrect
 
 !/!333:Message when restoring a bad save game
 !=!Illegal saved game file.
-!G!Ungültige gespeicherte Spieldatei.
-!S!Archivo de partida guardado no válido
+!G!Ungï¿½ltige gespeicherte Spieldatei.
+!S!Archivo de partida guardado no vï¿½lido
 !I!File di salvataggio non valido.
 !F!Fichier de sauvegarde non conforme.
 
 !/!334:error message when saving a game
 !=!Unable to save current game.
-!G!Aktuelles Spiel speichern nicht möglich.
+!G!Aktuelles Spiel speichern nicht mï¿½glich.
 !S!No se puede guardar la partida actual.
 !I!Impossibile salvare questa partita.
 !F!Impossible de sauver la partie en cours.
 
 !/!335:Message when restoring a bad save game
 !=!Unable to load game.
-!G!Spiel laden nicht möglich.
+!G!Spiel laden nicht mï¿½glich.
 !S!No se puede cargar la partida.
 !I!Impossibile caricare la partita.
 !F!Impossible de charger la partie.
@@ -2406,30 +2406,30 @@
 !/!336:In Load/Save game dialog, represents an empty slot
 !=!Empty
 !G!Leer
-!S!Vacío
+!S!Vacï¿½o
 !I!Vuoto
 !F!Vide
 
 !/!337:Unable to create directory.
 !=!Unable to create directory.
-!G!Verzeichniserstellung nicht möglich.
+!G!Verzeichniserstellung nicht mï¿½glich.
 !S!No se puede crear directorio.
 !I!Impossibile creare la directory.
-!F!Création de répertoire impossible.
+!F!Crï¿½ation de rï¿½pertoire impossible.
 
 !/!338:Error Message when restoring a save game
 !=!There are no saved games.
 !G!Es gibt keine gespeicherten Spiele.
 !S!No hay partidas guardadas.
 !I!Non esiste alcuna partita salvata.
-!F!Aucune partie n'a été sauvegardée.
+!F!Aucune partie n'a ï¿½tï¿½ sauvegardï¿½e.
 
 !/!339:There are no valid missions in the mission directory.
 !=!There are no valid missions in the mission directory.
-!G!Im Missionsverzeichnis gibt es keine gültigen Missionen.
-!S!No hay misiones válidas en el directorio de misiones.
+!G!Im Missionsverzeichnis gibt es keine gï¿½ltigen Missionen.
+!S!No hay misiones vï¿½lidas en el directorio de misiones.
 !I!Non esistono missioni valide nella directory delle missioni.
-!F!Il n'y a pas de missions valides dans le répertoire de missions.
+!F!Il n'y a pas de missions valides dans le rï¿½pertoire de missions.
 
 !/!340:Window title for load game dialog
 !=!Load Game
@@ -2448,14 +2448,14 @@
 !/!342:Description
 !=!Description
 !G!Beschreibung
-!S!Descripción
+!S!Descripciï¿½n
 !I!Descrizione
 !F!Description
 
 !/!343:in Detail configuration,label for fast headlight option
 !=!Fast Headlight
 !G!Schneller Scheinw.
-!S!Faro rápido
+!S!Faro rï¿½pido
 !I!Fanale rapido
 !F!Phare Rapide
 
@@ -2493,7 +2493,7 @@
 !G!Gegenmassn. -
 !S!Contramed ant
 !I!contromis prec
-!F!leurre préc.
+!F!leurre prï¿½c.
 
 !/!349:In keyboard config menu
 !=!next cntr meas
@@ -2514,15 +2514,15 @@
 !=!Joystick Sensitivity
 !G!Joystickempfindlichkeit
 !S!Sensibilidad del joystick
-!I!Sensibilità del joystick
-!F!Sensibilité du joystick
+!I!Sensibilitï¿½ del joystick
+!F!Sensibilitï¿½ du joystick
 
 !/!352:in game controller config menu
 !=!Mouse Sensitivity
 !G!Mausempfindlichkeit
-!S!Sensibilidad del ratón
-!I!Sensibilità del mouse
-!F!Sensibilité de la souris
+!S!Sensibilidad del ratï¿½n
+!I!Sensibilitï¿½ del mouse
+!F!Sensibilitï¿½ de la souris
 
 !/!353:keyconfig option for headlight toggle
 !=!headlight
@@ -2568,8 +2568,8 @@
 
 !/!359:in help screen
 !=!Go To Guide-Bot Menu
-!G!Guide-Bot Menü aufrufen
-!S!Ir a menú de roboguía
+!G!Guide-Bot Menï¿½ aufrufen
+!S!Ir a menï¿½ de roboguï¿½a
 !I!Vai al menu Robot-Guida
 !F!Passer au Menu GuideBot
 
@@ -2582,7 +2582,7 @@
 
 !/!361:in help screen
 !=!Select Primary Weapon
-!G!Primärwaffe auswählen
+!G!Primï¿½rwaffe auswï¿½hlen
 !S!Seleccionar arma principal
 !I!Seleziona arma principale
 !F!Choix Arme Primaire
@@ -2596,15 +2596,15 @@
 
 !/!363:in help screen
 !=!Select Secondary Weapon
-!G!Sekundärwaffe auswählen
+!G!Sekundï¿½rwaffe auswï¿½hlen
 !S!Seleccionar arma secundaria
 !I!Seleziona arma secondaria
 !F!Choix Arme Secondaire
 
 !/!364:for use in the demo: unavailable features in demo
 !=!Not available in this version.
-!G!In dieser Version nicht verfügbar.
-!S!No está disponible en esta versión.
+!G!In dieser Version nicht verfï¿½gbar.
+!S!No estï¿½ disponible en esta versiï¿½n.
 !I!Non disponibile in questa versione.
 !F!Non disponible dans cette version.
 
@@ -2613,14 +2613,14 @@
 !G!%s als Standard festgelegt
 !S!%s establecido como predeterminado
 !I!%s impostato come predefinito
-!F!%s défini par défaut
+!F!%s dï¿½fini par dï¿½faut
 
 !/!366:Main multiplayer menu
 !=!Set Selected as Default
 !G!Als Standard festlegen
 !S!Establecer seleccionado como predeterminado
 !I!Imposta selezionato come predefinito
-!F!enreg. comme défaut
+!F!enreg. comme dï¿½faut
 
 !/!367:Help
 !=!Help
@@ -2645,7 +2645,7 @@
 
 !/!370:Used on file dialog
 !=!Open
-!G!Öffnen
+!G!ï¿½ffnen
 !S!Abrir
 !I!Apri
 !F!Ouvrir
@@ -2655,28 +2655,28 @@
 !G!Keine Multiplayer-Dateien gefunden.
 !S!No se encuentran archivos multijugador
 !I!File multigiocatore non trovato.
-!F!Aucun fichier multijoueur trouvé.
+!F!Aucun fichier multijoueur trouvï¿½.
 
 !/!372:Multiplayer start game options menu -- Ships/Powerups allowed
 !=!Save Multiplayer Settings
 !G!Multiplayer-Einstellungen speichern
-!S!Guardar configuración multijugador
+!S!Guardar configuraciï¿½n multijugador
 !I!Salva impostazioni multigiocatore
-!F!Enreg paramètres multijoueur
+!F!Enreg paramï¿½tres multijoueur
 
 !/!373:Multiplayer start game options menu -- Ships/Powerups allowed
 !=!Load Multiplayer Settings
 !G!Multiplayer-Einstellungen laden
-!S!Cargar configuración multijugador
+!S!Cargar configuraciï¿½n multijugador
 !I!Carica impostazioni multigiocatore
-!F!charger paramètres multijoueur
+!F!charger paramï¿½tres multijoueur
 
 !/!374:Multiplayer start game options menu -- Ships/Powerups allowed
 !=!Allowed items
 !G!Zugelassene Objekte
 !S!Objetos permitidos
 !I!Elementi consentiti
-!F!equipement autorisé
+!F!equipement autorisï¿½
 
 !/!375:Multiplayer start game options menu -- Ships/Powerups allowed
 !=!Disallowed items
@@ -2690,7 +2690,7 @@
 !G!Zugelassene Schiffe
 !S!Naves permitidas
 !I!Navi consentite
-!F!Vaisseaux autorisés
+!F!Vaisseaux autorisï¿½s
 
 !/!377:Multiplayer start game options menu -- Ships/Powerups allowed
 !=!Disallowed Ships
@@ -2718,28 +2718,28 @@
 !G!Zugelassene Schiffe:
 !S!Naves permitidas:
 !I!Navi consentite:
-!F!Vaisseaux autorisés
+!F!Vaisseaux autorisï¿½s
 
 !/!381: help in weapon autoselect config screen
 !=!Select weapon to switch that slot with another weapon.
-!G!Wählen Sie die durch eine andere Waffe zu ersetzende Waffe aus.
+!G!Wï¿½hlen Sie die durch eine andere Waffe zu ersetzende Waffe aus.
 !S!Seleccionar arma para intercambiar ranura con otra.
 !I!Seleziona arma per commutare lo slot con un'altra arma.
-!F!Sélectionnez l'arme à déplacer.
+!F!Sï¿½lectionnez l'arme ï¿½ dï¿½placer.
 
 !/!382:help in weapon autoselect config screen
 !=!To disable a weapon, click on the 'X' button or use CTRL-C on highlighted weapon.
-!G!Um Waffen zu deaktivieren, auf 'X' klicken oder Waffe markieren und Strg-C drücken.
-!S!Para desactivar un arma, haz clic en el botón "X" o pulsa Ctrl+C en el arma resaltada
+!G!Um Waffen zu deaktivieren, auf 'X' klicken oder Waffe markieren und Strg-C drï¿½cken.
+!S!Para desactivar un arma, haz clic en el botï¿½n "X" o pulsa Ctrl+C en el arma resaltada
 !I!Per disattivare un'arma, fai clic sul pulsante 'X' o premi CTRL+C sull'arma evidenziata.
-!F!Pour désactiver une arme, cliquez sur 'X' ou utilisez CTRL-C sur l'arme sélectionnée.
+!F!Pour dï¿½sactiver une arme, cliquez sur 'X' ou utilisez CTRL-C sur l'arme sï¿½lectionnï¿½e.
 
 !/!383:Used in controller config help
 !=!Function may be configured using:
 !G!Funktion konfigurieren mit:
-!S!Esta función se puede configurar con:
-!I!La funzione può essere configurata utilizzando:
-!F!Définissez cette fonction avec le
+!S!Esta funciï¿½n se puede configurar con:
+!I!La funzione puï¿½ essere configurata utilizzando:
+!F!Dï¿½finissez cette fonction avec le
 
 !/!384:help in weapon autoselect config screen
 !=!Exchange with:
@@ -2753,18 +2753,18 @@
 !G!Deaktivieren
 !S!Desactivar
 !I!Disattiva
-!F!Désactiver
+!F!Dï¿½sactiver
 
 !/!386:weapon autoselect config screen
 !=!Primary
-!G!Primäre
+!G!Primï¿½re
 !S!Principal
 !I!Principale
 !F!Primaire
 
 !/!387:weapon autoselect config screen
 !=!Secondary
-!G!Sekundäre
+!G!Sekundï¿½re
 !S!Secundario
 !I!Secondaria
 !F!Secondaire
@@ -2778,7 +2778,7 @@
 
 !/!389:weapon autoselect config screen
 !=!Highest
-!G!Höchste
+!G!Hï¿½chste
 !S!Superior
 !I!Superiore
 !F!Maximum
@@ -2793,9 +2793,9 @@
 !/!391:Used in help screen
 !=!Start/Stop Demo Recording
 !G!Start/Stop Demoaufnahme
-!S!Iniciar/detener grabación de demo
+!S!Iniciar/detener grabaciï¿½n de demo
 !I!Inizia/termina la registrazione della demo
-!F!lancer/arrêter enregistrement démo
+!F!lancer/arrï¿½ter enregistrement dï¿½mo
 
 !/!392:Used in keyconfig 
 !=!cycle primary
@@ -2814,7 +2814,7 @@
 !/!394:Used in Menu
 !=!Credits
 !G!Credits
-!S!Créditos
+!S!Crï¿½ditos
 !I!Crediti
 !F!Credits
 
@@ -2841,52 +2841,52 @@
 
 !/!398:Used in help screen
 !=!Go To Multiplayer On-Screen Menu
-!G!Multiplayer On-Screen-Menü aufrufen
-!S!Ir a menú multijugador en pantalla 
+!G!Multiplayer On-Screen-Menï¿½ aufrufen
+!S!Ir a menï¿½ multijugador en pantalla 
 !I!Vai al menu su schermo multigiocatore
 !F!Atteindre Menu Multijoueur
 
 !/!399:Main menu
 !=!View Demo
 !G!Demo ansehen
-!S!Ver demostración
+!S!Ver demostraciï¿½n
 !I!Visualizza demo
 !F!Voir Demo
 
 !/!400:hud
 !=!Recording Demo
 !G!Demo aufnehmen
-!S!Grabar demostración
+!S!Grabar demostraciï¿½n
 !I!Registra demo
-!F!Enregistrement Démo
+!F!Enregistrement Dï¿½mo
 
 !/!401:hud
 !=!Playing Demo
 !G!Demo abspielen
-!S!Reproducir demostración
+!S!Reproducir demostraciï¿½n
 !I!Riproduci demo
-!F!Lecture de la démo
+!F!Lecture de la dï¿½mo
 
 !/!402:Demo recording dialog
 !=!Demo FileName
 !G!Demo Dateiname
-!S!Nombre archivo demostración
+!S!Nombre archivo demostraciï¿½n
 !I!Nome file demo
-!F!Nom Démo
+!F!Nom Dï¿½mo
 
 !/!403:Demo recording error
 !=!Unable to save demo file.
-!G!Demodatei speichern nicht möglich.
-!S!No se puede guardar archivo demostración.
+!G!Demodatei speichern nicht mï¿½glich.
+!S!No se puede guardar archivo demostraciï¿½n.
 !I!Impossibile salvare il file demo.
-!F!Enregistrement du fichier de démo impossible.
+!F!Enregistrement du fichier de dï¿½mo impossible.
 
 !/!404:Demo recording hud message
 !=!Demo file saved.
 !G!Demodatei gespeichert.
-!S!Archivo demostración guardado.
+!S!Archivo demostraciï¿½n guardado.
 !I!File demo salvato.
-!F!Fichier de démo enregistré.
+!F!Fichier de dï¿½mo enregistrï¿½.
 
 !/!405:Goal Status (TelCom Main menu button label)
 !=!Objectives
@@ -2897,38 +2897,38 @@
 
 !/!406:Demo recording error
 !=!Unable to create demo file.
-!G!Demodatei erstellen nicht möglich.
-!S!No se puede crear archivo demostración.
+!G!Demodatei erstellen nicht mï¿½glich.
+!S!No se puede crear archivo demostraciï¿½n.
 !I!Impossibile creare file demo.
-!F!Création du fichier de démo impossible.
+!F!Crï¿½ation du fichier de dï¿½mo impossible.
 
 !/!407:Demo playback error
 !=!Unable to load demo file.
-!G!Demodatei laden nicht möglich.
-!S!No se puede cargar archivo demostración.
+!G!Demodatei laden nicht mï¿½glich.
+!S!No se puede cargar archivo demostraciï¿½n.
 !I!Impossibile caricare file demo.
 
 
-!F!Chargement du fichier de démo impossible.
+!F!Chargement du fichier de dï¿½mo impossible.
 
 !/!408:Demo playback error
 !=!Bad Demo file; unable to read.
-!G!Ungültige Demodatei: Lesen nicht möglich.
-!S!Archivo demostración deteriorado; no se puede leer.
+!G!Ungï¿½ltige Demodatei: Lesen nicht mï¿½glich.
+!S!Archivo demostraciï¿½n deteriorado; no se puede leer.
 !I!Impossibile leggere il file demo. File danneggiato.
-!F!Fichier de démo illisible. 
+!F!Fichier de dï¿½mo illisible. 
 
 !/!409:Post Demo playack menu
 !=!Min. FPS: %.2f
 !G!Min. FPS: %.2f 
-!S!FPS mín: %.2f 
+!S!FPS mï¿½n: %.2f 
 !I!FPS min.: %.2f
 !F!FPS min.: %.2f
 
 !/!410:Post Demo playack menu
 !=!Max. FPS: %.2f
 !G!Max. FPS: %.2f 
-!S!FPS máx: %.2f 
+!S!FPS mï¿½x: %.2f 
 !I!FPS max: %.2f
 !F!FPS max.: %.2f
 
@@ -2949,37 +2949,37 @@
 !/!413:Hud message for Demo playback
 !=!Demo Playback Paused
 !G!Demo Playback angehalten
-!S!Demostración detenida
+!S!Demostraciï¿½n detenida
 !I!Riproduzione demo in pausa
-!F!Démo en pause
+!F!Dï¿½mo en pause
 
 !/!414:Mission Downloading screens
 !=!Would you like to download it?
-!G!Möchten Sie es herunterladen?
-!S!¿Quieres descargarla?
+!G!Mï¿½chten Sie es herunterladen?
+!S!ï¿½Quieres descargarla?
 !I!Procedere allo scaricamento?
-!F!Voulez-vous la télécharger ?
+!F!Voulez-vous la tï¿½lï¿½charger ?
 
 !/!415:Mission Downloading screens
 !=!You do not have this mission installed.
 !G!Diese Mission ist nicht installiert.
-!S!No has instalado esta misión
+!S!No has instalado esta misiï¿½n
 !I!Non hai installato questa missione.
-!F!Cette mission n'est pas installée.
+!F!Cette mission n'est pas installï¿½e.
 
 !/!416:Mission Downloading screens
 !=!Download Mission
 !G!Mission herunterladen
-!S!Descargar misión
+!S!Descargar misiï¿½n
 !I!Scarica missione
-!F!Télécharger mission
+!F!Tï¿½lï¿½charger mission
 
 !/!417:Mission Downloading screens
 !=!Downloading: %s
 !G!Herunterladen: %s
 !S!Descargando: %s
 !I!Scaricamento di: %s
-!F!Téléchargement de %s
+!F!Tï¿½lï¿½chargement de %s
 
 !/!418:Mission Downloading screens
 !=!Received: %d 
@@ -3000,7 +3000,7 @@
 !G!Verstrichene Zeit: %s
 !S!Tiempo transcurrido: %s
 !I!Tempo trascorso: %s
-!F!Temps écoulé: %s
+!F!Temps ï¿½coulï¿½: %s
 
 !/!421:Mission Downloading screens
 !=!Time Left: %s
@@ -3011,17 +3011,17 @@
 
 !/!422:Mission Downloading screens
 !=!Transfer Rate: %d Bytes/Second
-!G!Übertragungsrate: %d Bytes/Sekunde
-!S!Velocidad de transmisión: %d bytes por segundo.
-!I!Velocità di trasmissione: %d byte al secondo.
+!G!ï¿½bertragungsrate: %d Bytes/Sekunde
+!S!Velocidad de transmisiï¿½n: %d bytes por segundo.
+!I!Velocitï¿½ di trasmissione: %d byte al secondo.
 !F!Taux de transfert: %d octets/sec
 
 !/!423:Mission Downloading screens
 !=!Unable to download the selected mission.
-!G!Herunterladen der ausgewählten Mission nicht möglich.
-!S!No se puede descargar la misión elegida.
+!G!Herunterladen der ausgewï¿½hlten Mission nicht mï¿½glich.
+!S!No se puede descargar la misiï¿½n elegida.
 !I!Impossibile scaricare la missione selezionata.
-!F!Impossible de télécharger la mission sélectionnée.
+!F!Impossible de tï¿½lï¿½charger la mission sï¿½lectionnï¿½e.
 
 !/!424:Mission Downloading screens
 !=!%d hr.
@@ -3061,14 +3061,14 @@
 !/!429:Multiplayer start game options menu
 !=!Time Limit
 !G!Zeitlimit
-!S!Límite de tiempo
+!S!Lï¿½mite de tiempo
 !I!Limite di tempo
 !F!Limite de temps
 
 !/!430:Multiplayer start game options menu
 !=!Goal Limit
 !G!Ziellimit
-!S!Límite de objetivo
+!S!Lï¿½mite de objetivo
 !I!Limite dell'obiettivo
 !F!objectif limite
 
@@ -3084,13 +3084,13 @@
 !G!Zugel. Schiffe/Objekte konfig.
 !S!Configurar naves/objetos permitidos
 !I!Configura navi/oggetti consentiti
-!F!équipement/vaisseaux autorisés
+!F!ï¿½quipement/vaisseaux autorisï¿½s
 
 !/!433:Multiplayer start game options menu
 !=!Server mode
 !G!Server-Modus
 !S!Modo de servidor
-!I!Modalità server
+!I!Modalitï¿½ server
 !F!Mode Serveur
 
 !/!434:Multiplayer start game options menu
@@ -3110,20 +3110,20 @@
 !/!436:Multiplayer start game options menu
 !=!Respawn Rate
 !G!Wiedereinstiegsrate
-!S!Velocidad resurrección
-!I!Velocità di ricomparsa
+!S!Velocidad resurrecciï¿½n
+!I!Velocitï¿½ di ricomparsa
 !F!Taux de vies
 
 !/!437:Multiplayer start game options menu
 !=!Use rotational velocity
 !G!Drehgeschwindigkeit verwenden
 !S!Utilizar velocidad de giro
-!I!Utilizza velocità di rotazione
+!I!Utilizza velocitï¿½ di rotazione
 !F!Utiliser vitesse rotationnelle
 
 !/!438:Multiplayer start game options menu
 !=!Movement averaging
-!G!Bewegungsschätzung
+!G!Bewegungsschï¿½tzung
 !S!Movimiento medio
 !I!Calcolo del movimento
 !F!Lissage Mouvement
@@ -3131,16 +3131,16 @@
 !/!439:Multiplayer start game options menu
 !=!Max. Players
 !G!Max. Spieler
-!S!Jugadores máximos
+!S!Jugadores mï¿½ximos
 !I!Num max giocatori
 !F!Nb max. joueurs 
 
 !/!440:Multiplayer start game options menu
 !=!%c Use restrictive weapon collisions
-!G!%c Beschränkte Waffenkollisionen verwenden
+!G!%c Beschrï¿½nkte Waffenkollisionen verwenden
 !S!%c Utilizar colisiones de armas restringidas
 !I!%c Utilizza collisioni di armi precise
-!F!%c Utiliser collisions d'armes précises
+!F!%c Utiliser collisions d'armes prï¿½cises
 
 !/!441:Multiplayer start game options menu
 !=!Bright player ships
@@ -3152,7 +3152,7 @@
 !/!442:Multiplayer start game options menu
 !=!Max terrain distance
 !G!Max. Gebietsentfernung
-!S!Distancia máx terreno
+!S!Distancia mï¿½x terreno
 !I!Distanza max terreno
 !F!visibilite du terrain 
 
@@ -3165,7 +3165,7 @@
 
 !/!444:Multiplayer start game options menu
 !=!Permissible Client/Server
-!G!Zulässiger Client/Server
+!G!Zulï¿½ssiger Client/Server
 !S!Cliente/servidor permisible
 !I!Client/server consentito
 !F!Client/Serveur acceptable
@@ -3174,34 +3174,34 @@
 !=!Adjust brightness
 !G!Helligkeit anpassen
 !S!Ajustar brillo
-!I!Regola luminosità
-!F!Ajuster la luminosité
+!I!Regola luminositï¿½
+!F!Ajuster la luminositï¿½
 
 !/!446:Set taunt macros
 !=!Set taunt macros
 !G!Hohn-Makros einstellen
-!S!Macros provocación
+!S!Macros provocaciï¿½n
 !I!Imposta macro provocazione
 !F!creer railleries
 
 !/!447:Macro #
 !=!Macro #
 !G!Makro Nr.
-!S!Nº macro 
+!S!Nï¿½ macro 
 !I!N. macro
 !F!Macro #
 
 !/!448:Taunt message
 !=!Gimme some sugar, baby!
 !G!Gib mir Zucker, Baby!
-!S!¡Dame azúcar, nena!
+!S!ï¿½Dame azï¿½car, nena!
 !I!Dammi dello zucchero, piccola!
 !F!Fais-moi vibrer !
 
 !/!449:Taunt message
 !=!Stop, drop, and roll!
 !G!Stoppen, fallen und rollen! 
-!S!¡Detente, tírate y rueda!
+!S!ï¿½Detente, tï¿½rate y rueda!
 !I!Fermati, abbassati e ruota!
 !F!Attention les yeux !
 
@@ -3209,42 +3209,42 @@
 !=!For every winner, there is a LOSER!
 !G!Wo ein Sieger ist, ist auch ein VERLIERER!
 !S!Por cada ganador hay un perdedor
-!I!Per ogni vincitore, c'è un PERDENTE!
+!I!Per ogni vincitore, c'ï¿½ un PERDENTE!
 !F!A chaque vainqueur son PERDANT !
 
 !/!451:Taunt message
 !=!I'm better than you. Deal with it!
 !G!Ich bin besser als Du. Sieh's ein!
-!S!Soy mejor que tú. Reconócelo.
+!S!Soy mejor que tï¿½. Reconï¿½celo.
 !I!Sono migliore di te. Riconoscilo!
 !F!J'suis meilleur que toi. Faudra t'y faire !
 
 !/!452:Taunt message
 !=!Kneel before Zod!
 !G!Knie vor mir nieder!
-!S!¡Arrodíllate ante mí!
+!S!ï¿½Arrodï¿½llate ante mï¿½!
 !I!Inginocchiati davanti a me!
 !F!A genoux devant moi !
 
 !/!453:Taunt message
 !=!It's good to be the king!
-!G!Es ist schön, der King zu sein!
-!S!Ser el rey no está mal
-!I!È bello essere il re!
-!F!Que c'est bon d'être le roi !
+!G!Es ist schï¿½n, der King zu sein!
+!S!Ser el rey no estï¿½ mal
+!I!ï¿½ bello essere il re!
+!F!Que c'est bon d'ï¿½tre le roi !
 
 !/!454:Taunt message
 !=!First you wanna kiss me, now you wanna kill me
-!G!Vorhin wolltest Du mich knutschen, und jetzt willst Du mich töten
-!S!Primero querías besarme y ahora quieres matarme
+!G!Vorhin wolltest Du mich knutschen, und jetzt willst Du mich tï¿½ten
+!S!Primero querï¿½as besarme y ahora quieres matarme
 !I!Prima volevi baciarmi, ora vuoi uccidermi
 !F!Faudra d'abord m'attraper !
 
 !/!455:Taunt message
 !=!This is gonna hurt you more than it hurts me
 !G!Das wird Dir mehr weh tun als mir
-!S!Te va a doler más que a mí
-!I!Farà più male a te che a me
+!S!Te va a doler mï¿½s que a mï¿½
+!I!Farï¿½ piï¿½ male a te che a me
 !F!Ne frappe jamais le premier ou tu perdras le combat. 
 
 !/!456: Error message when a file can't be found
@@ -3252,32 +3252,32 @@
 !G!Datei nicht gefunden
 !S!No se encuentra el archivo
 !I!File non trovato
-!F!Fichier non trouvé 
+!F!Fichier non trouvï¿½ 
 
 !/!457: Audio taunt import error message when the file isn't in RIFF format
 !=!File Not In RIFF Format
 !G!Datei nicht im RIFF-Format
-!S!El archivo no está en formato RIFF
+!S!El archivo no estï¿½ en formato RIFF
 !I!File non in formato RIFF
-!F!Le fichier doit être au format RIFF.
+!F!Le fichier doit ï¿½tre au format RIFF.
 
 !/!458: Audio taunt error message when the given file isn't a wave file
 !=!File Not A WAVE 
 !G!Datei nicht im WAVE-Format
 !S!No es un archivo WAVE
-!I!Non è un file WAVE
-!F!Le fichier doit être au format WAVE.
+!I!Non ï¿½ un file WAVE
+!F!Le fichier doit ï¿½tre au format WAVE.
 
 !/!459: Error message when the given file is invalid
 !=!Invalid File
-!G!Ungültige Datei
-!S!Archivo no válido
+!G!Ungï¿½ltige Datei
+!S!Archivo no vï¿½lido
 !I!File non valido
 !F!Fichier Non Valide
 
 !/!460: Audio taunt import error message when the file format isn't supported
 !=!File Format Not Supported.
-!G!Dateiformat wird nicht unterstützt.
+!G!Dateiformat wird nicht unterstï¿½tzt.
 !S!No se admite el formato de archivo.
 !I!Formato di file non supportato.
 !F!Format non pris en charge.
@@ -3287,35 +3287,35 @@
 !G!WAV muss im Mono-Format sein.
 !S!WAV debe estar en formato mono.
 !I!WAV deve essere in formato mono.
-!F!WAV doit être en format Mono.
+!F!WAV doit ï¿½tre en format Mono.
 
 !/!462: Audio taunt import error when the sample rate is not correct
 !=!WAV Must Have 22,050 Sample Rate.
 !G!WAV muss Frequenzrate 22.050 haben.
 !S!El WAV debe tener una tasa de muestreo de 22.050
 !I!WAV deve avere una frequenza di campionamento di 22.050.
-!F!WAV doit avoir un taux d'échantillonnage de 22 050.
+!F!WAV doit avoir un taux d'ï¿½chantillonnage de 22 050.
 
 !/!463: Audio taunt import error message when the bit depth of the file is not supported
 !=!Invalid Bit Depth; Must Be 8 or 16.
-!G!Ungültige Bitanzahl: Muss 8 oder 16 sein.
-!S!Resolución de bits no válida; debe ser 8 ó 16.
+!G!Ungï¿½ltige Bitanzahl: Muss 8 oder 16 sein.
+!S!Resoluciï¿½n de bits no vï¿½lida; debe ser 8 ï¿½ 16.
 !I!Risoluzione in bit non valida; deve essere 8 o 16.
-!F!Résolution en bits incorrecte ; elle doit être de 8 ou 16.
+!F!Rï¿½solution en bits incorrecte ; elle doit ï¿½tre de 8 ou 16.
 
 !/!464: Audio taunt import message when no data was found in the wav file
 !=!No Data Found In WAV.
 !G!Keine Daten in WAV gefunden.
 !S!No se encuentran datos en el WAV.
 !I!Nessun dato trovato nel WAV.
-!F!Aucune donnée trouvée dans WAV.
+!F!Aucune donnï¿½e trouvï¿½e dans WAV.
 
 !/!465: Audio taunt import error message when the output file already exists
 !=!OSF File Already Exists; Can't Overwrite.
-!G!OFS-Datei existiert bereits; kann nicht überschrieben werden.
+!G!OFS-Datei existiert bereits; kann nicht ï¿½berschrieben werden.
 !S!Archivo OSF ya existe; no se puede sustituir.
-!I!Il file OSF esiste già; impossibile sovrascriverlo.
-!F!Le fichier OSF existe déjà ; il ne peut être écrasé.
+!I!Il file OSF esiste giï¿½; impossibile sovrascriverlo.
+!F!Le fichier OSF existe dï¿½jï¿½ ; il ne peut ï¿½tre ï¿½crasï¿½.
 
 !/!466: Audio taunt import message when there is an internal error
 !=!Internal Error
@@ -3327,7 +3327,7 @@
 !/!467: Audio taunt import error message when the compression failed
 !=!Compression Failure
 !G!Komprimierungsfehler
-!S!Fallo de compresión
+!S!Fallo de compresiï¿½n
 !I!Errore di compressione
 !F!Echec de compression.
 
@@ -3336,14 +3336,14 @@
 !G!Kein Speicherplatz mehr
 !S!No hay suficiente memoria
 !I!Memoria insufficiente
-!F!Mémoire insuffisante.
+!F!Mï¿½moire insuffisante.
 
 !/!469: Audio taunt error message when the OSF can't be opened for writng
 !=!Can't Open OSF For Writing
-!G!OSF kann zum Schreiben nicht geöffnet werden
+!G!OSF kann zum Schreiben nicht geï¿½ffnet werden
 !S!No se puede abrir OSF para escribir
 !I!Impossibile aprire l'OSF per la scrittura
-!F!Impossible d'ouvrir OSF pour écriture.
+!F!Impossible d'ouvrir OSF pour ï¿½criture.
 
 !/!470: There was no error
 !=!No Error
@@ -3356,22 +3356,22 @@
 !=!Adjust the brightness slider so that the dark
 !G!Stellen Sie die Helligkeit so ein, dass die dunkelgraue
 !S!Ajusta el deslizador de brillo para que el cuadro
-!I!Regolare l'indicatore di scorrimento della luminosità in modo che la
-!F!Ajustez la barre de défilement de façon à ce que 
+!I!Regolare l'indicatore di scorrimento della luminositï¿½ in modo che la
+!F!Ajustez la barre de dï¿½filement de faï¿½on ï¿½ ce que 
 
 !/!472: In graphics config, gamma set description line 2
 !=!grey box above is easily visible inside the black box
-!G!Fläche gut in der schwarzen Box sichtbar ist
-!S!gris oscuro de arriba se vea fácilmente en el interior del cuadro negro
+!G!Flï¿½che gut in der schwarzen Box sichtbar ist
+!S!gris oscuro de arriba se vea fï¿½cilmente en el interior del cuadro negro
 !I!casella superiore di colore grigio scuro sia facilmente visibile nella casella nera
-!F!le carré gris sombre apparaisse dans le carré noir. 
+!F!le carrï¿½ gris sombre apparaisse dans le carrï¿½ noir. 
 
 !/!473: Bit depth radio list in config menus
 !=!Bit Depth
 !G!Bitanzahl
 !S!Profundidad de color
 !I!Risoluzione in bit
-!F!Résolution
+!F!Rï¿½solution
 
 !/!474: 16 bit, bit depth
 !=!16 Bit
@@ -3411,30 +3411,30 @@
 !/!479: In config menus, the mouse enabled check box
 !=!Mouse
 !G!Maus
-!S!Ratón
+!S!Ratï¿½n
 !I!Mouse
 !F!Souris
 
 !/!480: In config menus, the checkbox for controller enabled
 !=!Controller Enabled
-!G!Steuergerät aktiviert
+!G!Steuergerï¿½t aktiviert
 !S!Controlador activado
-!I!Unità di controllo attivata
-!F!Contrôleur actif
+!I!Unitï¿½ di controllo attivata
+!F!Contrï¿½leur actif
 
 !/!481: In the config menu, the format label for joystick sensitivity sliders (it will become "Joystick X Sensitivity")
 !=!Joystick %c Sensitivity
 !G!Joystick %c Empfindlichkeit
 !S!Sensibilidad joystick %c 
-!I!Sensibilità joystick %c
-!F!Sensibilité Joystick %c
+!I!Sensibilitï¿½ joystick %c
+!F!Sensibilitï¿½ Joystick %c
 
 !/!482: In the config menus, just like joystick, its the label for the sensitivity sliders for the mouse axis
 !=!Mouse %c Sensitivity
 !G!Maus %c Empfindlichkeit
-!S!Sensibilidad ratón %c
-!I!Sensibilità mouse %c
-!F!Sensibilité Souris %c
+!S!Sensibilidad ratï¿½n %c
+!I!Sensibilitï¿½ mouse %c
+!F!Sensibilitï¿½ Souris %c
 
 !/!483: Configure Force Feedback joystick, option in config menu, only shows when there is a force feedback device connected
 !=!Configure Force-feedback
@@ -3459,7 +3459,7 @@
 
 !/!486: Very high settings
 !=!Highest
-!G!Höchste
+!G!Hï¿½chste
 !S!Super
 !I!Massimo
 !F!Maximum
@@ -3475,7 +3475,7 @@
 !=!Object Complex
 !G!Objektkomplex
 !S!Objeto Complej.
-!I!Complessità dell'oggetto
+!I!Complessitï¿½ dell'oggetto
 !F!Objet
 
 !/!489: Enable fog setting in detail config
@@ -3487,7 +3487,7 @@
 
 !/!490: In detail settings, for light coronas
 !=!Light Coronas
-!G!Lichtkränze
+!G!Lichtkrï¿½nze
 !S!Coronas de luz
 !I!Corone di luce
 !F!Halos lumineux
@@ -3538,7 +3538,7 @@
 !=!Controller AutoCenter
 !G!Joystick Autozentr.
 !S!Autocentrado controlador
-!I!Autocentratura unità di controllo
+!I!Autocentratura unitï¿½ di controllo
 !F!Autocentr. Controleur
 
 !/!498: In force feedback options, label for force gain slider
@@ -3553,7 +3553,7 @@
 !G!Hoch
 !S!Alto
 !I!Alto
-!F!Elevé
+!F!Elevï¿½
 
 !/!500: format string for hud message when the headlight is turned on/off
 !=!Headlight turned %s.
@@ -3578,10 +3578,10 @@
 
 !/!503: In controller config, for rear view
 !=!rear view
-!G!Rückansicht
-!S!visión trasera
+!G!Rï¿½ckansicht
+!S!visiï¿½n trasera
 !I!vista posteriore
-!F!vue arrière
+!F!vue arriï¿½re
 
 !/!504: In controller config, to label to enable/disable the joystick
 !=!Joystick
@@ -3592,38 +3592,38 @@
 
 !/!505: Dedicated server message when couldn't init dll
 !=!Couldn't initialize connection '%s' DLL.
-!G!Initialisieren der Verbindung '%s' DLL nicht möglich.
-!S!No se puede inicializar la DLL de conexión "%s".
+!G!Initialisieren der Verbindung '%s' DLL nicht mï¿½glich.
+!S!No se puede inicializar la DLL de conexiï¿½n "%s".
 !I!Impossibile inizializzare la DLL "%s" di connessione.
 !F!Impossible d'initialiser la connexion '%s' DLL.
 
 !/!506: Dedicated server message when the dll is inited
 !=!Connection DLL initialized.
 !G!Verbindungs DLL initialisiert.
-!S!DLL de conexión inicializada.
+!S!DLL de conexiï¿½n inicializada.
 !I!DLL di connessione inizializzata.
-!F!Connexion DLL initialisée.
+!F!Connexion DLL initialisï¿½e.
 
 !/!507: Dedicated server message when it couldn't load connection dll
 !=!Error loading connection DLL '%s'.
 !G!Fehler beim Laden der Verbindung DLL '%s'.
-!S!Error al cargar DLL de conexión "%s".
+!S!Error al cargar DLL de conexiï¿½n "%s".
 !I!Errore di caricamento della DLL di connessione "%s".
 !F!Erreur du chargement de la connexion DLL '%s'
 
 !/!508: Dedicated server message when it couldn't load the mission
 !=!Couldn't load mission '%s' for dedicated server.
-!G!Mission '%s' für zugeordneten Server laden nicht möglich.
-!S!No se puede cargar la misión "%s" en el servidor exclusivo.
+!G!Mission '%s' fï¿½r zugeordneten Server laden nicht mï¿½glich.
+!S!No se puede cargar la misiï¿½n "%s" en el servidor exclusivo.
 !I!Impossibile caricare la missione "%s" per il server dedicato.
-!F!Impossible de charger '%s' pour serveur dédié.
+!F!Impossible de charger '%s' pour serveur dï¿½diï¿½.
 
 !/!509: Dedicated server message when the mission is loaded
 !=!Mission '%s' loaded successfully.
 !G!Mission '%s' erfolgreich geladen.
-!S!Misión "%s" cargada correctamente.
+!S!Misiï¿½n "%s" cargada correctamente.
 !I!Missione "%s" caricata correttamente.
-!F!Mission '%s' chargée avec succès.
+!F!Mission '%s' chargï¿½e avec succï¿½s.
 
 !/!510: Dedicated server player name
 !=!-Server-
@@ -3634,38 +3634,38 @@
 
 !/!511: Dedicated server message for a bad command line
 !=!Bad command line
-!G!Ungültige Kommandozeile
-!S!Línea de comando defectuosa
+!G!Ungï¿½ltige Kommandozeile
+!S!Lï¿½nea de comando defectuosa
 !I!Riga di comando errata
 !F!Ligne de commande incorrecte
 
 !/!512: Dedicated server message when it can't find config file
 !=!Missing server config filename
 !G!Server Konfigurations-Dateiname fehlt
-!S!Falta nombre de archivo de configuración del servidor
+!S!Falta nombre de archivo de configuraciï¿½n del servidor
 !I!Nome file di configurazione server mancante
 !F!Nom de fichier de config. du serveur manquant
 
 !/!513: Dedicated server message when the config file is bad
 !=!Unable to open server config '%s' or bad file.
-!G!Öffnen von Server Konfiguration '%s' nicht möglich oder ungültige Datei. 
-!S!No se puede abrir la configuración del servidor "%s" o el archivo está defectuoso.
+!G!ï¿½ffnen von Server Konfiguration '%s' nicht mï¿½glich oder ungï¿½ltige Datei. 
+!S!No se puede abrir la configuraciï¿½n del servidor "%s" o el archivo estï¿½ defectuoso.
 !I!Impossibile aprire la configurazione server "%s" o file danneggiato.
 !F!Impossible d'ouvrir la config. du serveur '%s' ou fichier non conforme.
 
 !/!514: Dedicated server message when the settings are loaded
 !=!Settings file loaded successfully.
 !G!Einstellungsdatei erfolgreich geladen.
-!S!Archivo de configuración cargado correctamente.
+!S!Archivo de configuraciï¿½n cargado correctamente.
 !I!File delle impostazioni caricato correttamente.
-!F!Fichier de paramètres chargé avec succès.
+!F!Fichier de paramï¿½tres chargï¿½ avec succï¿½s.
 
 !/!515: Dedicated server message there was an error loading the settings
 !=!Settings file failed to load.
-!G!Einstellungsdatei laden nicht möglich.
-!S!No se puede cargar el archivo de configuración.
+!G!Einstellungsdatei laden nicht mï¿½glich.
+!S!No se puede cargar el archivo de configuraciï¿½n.
 !I!Impossibile caricare il file di configurazione.
-!F!Echec du chargement du fichier de paramètres.
+!F!Echec du chargement du fichier de paramï¿½tres.
 
 !/!516: Dedicated server message for disallowed objects
 !=!Disallowing objected named %s.
@@ -3679,82 +3679,82 @@
 !G!Objekte %s zugelassen.
 !S!Nombre de objeto permitido %s.
 !I!Oggetto %s consentito.
-!F!Objet %s autorisé.
+!F!Objet %s autorisï¿½.
 
 !/!518: Dedicated server message a variable is set/changed
 !=!Setting '%s' variable to %s.
 !G!Variable '%s' wird auf %s gesetzt.
 !S!Asignar a variable "%s" el valor %s.
 !I!Imposta la variabile "%s" su %s.
-!F!Changement de la variable '%s' à %s.
+!F!Changement de la variable '%s' ï¿½ %s.
 
 !/!519: Dedicated server message when a bad command is given
 !=!Unrecognized command or bad format.
-!G!Ungültiges Kommando oder falsches Format.
-!S!Comando no reconocido o formato erróneo.
+!G!Ungï¿½ltiges Kommando oder falsches Format.
+!S!Comando no reconocido o formato errï¿½neo.
 !I!Comando non riconosciuto o formato non valido.
 !F!Commande non reconnue ou format non conforme.
 
 !/!520: Dedicated server message password prompt
 !=!Enter Password:
 !G!Passwort eingeben:
-!S!Escribe contraseña:
+!S!Escribe contraseï¿½a:
 !I!Immetti password:
 !F!Entrer mot de passe:
 
 !/!521: Dedicated server message when it rejects a remote host connect
 !=!Rejecting connection from remote host. (%s)
 !G!Verbindung von Remote-Host abgelehnt. (%s)
-!S!Rechazando conexión de anfitrión remoto. (%s)
+!S!Rechazando conexiï¿½n de anfitriï¿½n remoto. (%s)
 !I!Impossibile connettere host remoto (%s).
-!F!Rejet de la connexion par hôte distant. (%s)
+!F!Rejet de la connexion par hï¿½te distant. (%s)
 
 !/!522: Dedicated server message for a new connection (%s is ip address)
 !=!New connection (%s)
 !G!Neue Verbindung (%s)
-!S!Nueva conexión (%s)
+!S!Nueva conexiï¿½n (%s)
 !I!Nuova connessione (%s)
 !F!Nouvelle connexion (%s)
 
 !/!523: Dedicated server message when the remote connection closes
 !=!Remote host %s closed the connection.
 !G!Remote-Host %s hat Verbindung getrennt.
-!S!El anfitrión remoto %s ha interrumpido la conexión.
+!S!El anfitriï¿½n remoto %s ha interrumpido la conexiï¿½n.
 !I!L'host remoto %s ha interrotto la connessione.
-!F!L'hôte distant %s a fermé la connexion.
+!F!L'hï¿½te distant %s a fermï¿½ la connexion.
 
 !/!524: Dedicated server message when there is a remote login
 !=!Remote host %s logged in.
 !G!Remote-Host %s eingeloggt.
-!S!El anfitrión remoto %s ha iniciado una sesión.
+!S!El anfitriï¿½n remoto %s ha iniciado una sesiï¿½n.
 !I!Host remoto %s collegato.
-!F!Hôte distant %s connecté.
+!F!Hï¿½te distant %s connectï¿½.
 
 !/!525: Dedicated server message when a bad pass is enter for a remote connect (%s is ip address)
 !=!Invalid login password from %s.
-!G!Ungültiges Passwort von %s.
-!S!Contraseña de inicio de %s no válida.
+!G!Ungï¿½ltiges Passwort von %s.
+!S!Contraseï¿½a de inicio de %s no vï¿½lida.
 !I!Password di collegamento non valida per %s.
 !F!Mot de passe d'ouverture de session de %s non valide.
 
 !/!526: Window title for Demo playback options dialog
 !=!Demo Playback options
 !G!Demo Abspieloptionen
-!S!Opciones reproducción demostración
+!S!Opciones reproducciï¿½n demostraciï¿½n
 !I!Opzioni di riproduzione demo
-!F!Options Lecture Démo
+!F!Options Lecture Dï¿½mo
 
 !/!527: Progress screen error if the module couldn't be loaded
 !=!Error Loading Module
 !G!Fehler beim Laden des Moduls
-!S!Error al cargar el módulo
+!S!Error al cargar el mï¿½dulo
 !I!Errore di caricamento modulo
 !F!Erreur Chargement Module
 
 !/!528: Message box text if the module couldn't be initialized during load
 !=!Error Initializing Game Module.
 !G!Fehler beim Initialisieren des Spielmoduls.
-!S!Error al inicializar el módulo del juego.
+!S!Error al inicializar el mï¿½dulo del juego.
 !I!Errore di inizializzazione modulo di gioco.
 !F!Erreur Initialisation Module de Jeu.
 
@@ -3768,84 +3768,84 @@
 !/!530: Message displayed when the user types in a d1/d2 cheat
 !=!Lamer!
 !G!Versager!
-!S!¡Tramposo!
+!S!ï¿½Tramposo!
 !I!Imbroglione!
 !F!Minable !
 
 !/!531: Hud message displayed when framerate is enable/disabled
 !=!Frame time: %s
 !G!Einzelbildrate: %s
-!S!Velocidad de constitución de imágenes: %s
-!I!Velocità fotogrammi: %s
-!F!Durée d'image: %s
+!S!Velocidad de constituciï¿½n de imï¿½genes: %s
+!I!Velocitï¿½ fotogrammi: %s
+!F!Durï¿½e d'image: %s
 
 !/!532: The option is being enabled
 !=!Enabled
 !G!Aktiviert
 !S!Activada
 !I!Attivata
-!F!Activé
+!F!Activï¿½
 
 !/!533: The option is being disabled
 !=!Disabled
 !G!Deaktiviert
 !S!Desactivada
 !I!Disattivata
-!F!Désactivé
+!F!Dï¿½sactivï¿½
 
 !/!534: Hud message for the texture cheat/test
 !=!Cool Textures!!
 !G!Coole Texturen!!
-!S!¡Bonitas texturas!
+!S!ï¿½Bonitas texturas!
 !I!Buone Texture!
 !F!Super textures !!
 
 !/!535: Hud message when textures are restored from cheat
 !=!Textures Back To Normal
-!G!Texturen auf normal zurückgesetzt 
+!G!Texturen auf normal zurï¿½ckgesetzt 
 !S!Restablecer texturas normales
 !I!Ristabilire texture normali
 !F!Retour aux textures normales
 
 !/!536: Hud message displayed when the invuln cheat is turned off
 !=!Your mother wont protect you now!
-!G!Deine Mutter wird Dich jetzt nicht schützen!
-!S!¡Tu madre no podrá protegerte ahora!
-!I!Tua madre non potrà proteggerti ora!
-!F!Ta mère n'est pas là pour t'aider ?!
+!G!Deine Mutter wird Dich jetzt nicht schï¿½tzen!
+!S!ï¿½Tu madre no podrï¿½ protegerte ahora!
+!I!Tua madre non potrï¿½ proteggerti ora!
+!F!Ta mï¿½re n'est pas lï¿½ pour t'aider ?!
 
 !/!537: Hud message displayed when you enter invuln mode by cheat
 !=!You're a wimp!
-!G!Sie sind ein Schwächling!
-!S!¡Eres un pringao!
+!G!Sie sind ein Schwï¿½chling!
+!S!ï¿½Eres un pringao!
 !I!Sei un baro!
-!F!Quel lâche tu fais !
+!F!Quel lï¿½che tu fais !
 
 !/!538: Hud message displayed when you leave the cloak cheat
 !=!You escape the darkness!
 !G!Sie verlassen die Dunkelheit!
-!S!¡Has escapado de la oscuridad!
-!I!Sei sfuggito all'oscurità!
+!S!ï¿½Has escapado de la oscuridad!
+!I!Sei sfuggito all'oscuritï¿½!
 !F!Tu sors de l'ombre ?!
 
 !/!539: Hud message displayed when you enter cloak cheat
 !=!You enter the darkness!
 !G!Sie betreten die Dunkelheit!
-!S!¡Has entrado en la oscuridad!
-!I!Sei entrato nell'oscurità!
-!F!Tu préfères rester dans l'ombre ?!
+!S!ï¿½Has entrado en la oscuridad!
+!I!Sei entrato nell'oscuritï¿½!
+!F!Tu prï¿½fï¿½res rester dans l'ombre ?!
 
 !/!540: Hud message when you enter the all weapons cheat
 !=!All weapons!
 !G!Alle Waffen!
-!S!¡Todas las armas!
+!S!ï¿½Todas las armas!
 !I!Tutte le armi!
 !F!Toutes armes !
 
 !/!541: Hud message when you enter the all robots dead cheat
 !=!All robots dead!
 !G!Alle Roboter sind tot!
-!S!¡Todos los robots están muertos!
+!S!ï¿½Todos los robots estï¿½n muertos!
 !I!Tutti i robot sono morti!
 !F!Tous les robots sont morts !
 
@@ -3859,23 +3859,23 @@
 !/!543: Window text for pause screen
 !=!The game is paused.\nPress Pause or click on OK to resume.
 !G!Pause eingeschaltet.\nZum Fortsetzen auf OK klicken.
-!S!El juego está detenido. Pulsa "Aceptar" para continuar.
-!I!La partita è in pausa. Premi OK per riprendere.
+!S!El juego estï¿½ detenido. Pulsa "Aceptar" para continuar.
+!I!La partita ï¿½ in pausa. Premi OK per riprendere.
 !F!La partie est en pause.\nAppuyez sur OK pour continuer.
 
 !/!544: exit game confirmation window title
 !=!Abort Mission
 !G!Mission abbrechen
-!S!Interrumpir misión.
+!S!Interrumpir misiï¿½n.
 !I!Interrompi la missione
 !F!Abandon de la mission
 
 !/!545: game exit confirmation text
 !=!Are You Sure You Want To Abort The Mission?
 !G!Sind Sie sicher, dass Sie die Mission abbrechen wollen?
-!S!¿Estás seguro de que quieres interrumpir la misión?
+!S!ï¿½Estï¿½s seguro de que quieres interrumpir la misiï¿½n?
 !I!Sei sicuro di voler interrompere la missione?
-!F!Etes-vous sûr de vouloir abandonner la mission ?
+!F!Etes-vous sï¿½r de vouloir abandonner la mission ?
 
 !/!546: Hud message displayed if the ship doesn't have a cockpit
 !=!This ship does not have a cockpit!
@@ -3889,7 +3889,7 @@
 !G!Ferngelenkt
 !S!guiado
 !I!teleguidato
-!F!guidé
+!F!guidï¿½
 
 !/!548: Hud display when in zoom view
 !=!zoom view
@@ -3902,8 +3902,8 @@
 !=!%.1f units
 !G!%.1f Einheiten
 !S!%.1f unidades
-!I!%.1f unità
-!F!%.1f unités
+!I!%.1f unitï¿½
+!F!%.1f unitï¿½s
 
 !/!550: Shields display on the hud
 !=!Shields
@@ -3915,7 +3915,7 @@
 !/!551: Hud display for energy
 !=!Energy
 !G!Energie
-!S!Energía
+!S!Energï¿½a
 !I!Energia
 !F!Energie
 
@@ -3931,21 +3931,21 @@
 !G!Unverwundbar
 !S!Invulnerable
 !I!Invulnerabile
-!F!Invulnérable
+!F!Invulnï¿½rable
 
 !/!554: Hud display for cloak
 !=!Cloaked
 !G!Getarnt
 !S!Camuflajeado
 !I!Occultato
-!F!Occulté
+!F!Occultï¿½
 
 !/!555: Team say prompt on hud
 !=!Team Say: %s
 !G!Team sagt: %s
 !S!El equipo dice: %s
 !I!La squadra dice: %s
-!F!Message de l'équipe: %s
+!F!Message de l'ï¿½quipe: %s
 
 !/!556: Marker prompt on hud
 !=!Marker: %s
@@ -3966,18 +3966,18 @@
 !G!Schalte ab.
 !S!Apagando.
 !I!Chiusura.
-!F!Arrêt.
+!F!Arrï¿½t.
 
 !/!559:Invalid team count (for variable team games)
 !=!Invalid team count
-!G!Ungültige Teamzahl
-!S!Cuenta de equipo no válida
+!G!Ungï¿½ltige Teamzahl
+!S!Cuenta de equipo no vï¿½lida
 !I!Conteggio squadre non valido
-!F!nombre d'équipes incorrect
+!F!nombre d'ï¿½quipes incorrect
 
 !/!560: Dedicated server message when opening a level
 !=!Opening level '%s'...
-!G!Öffne Level '%s'...
+!G!ï¿½ffne Level '%s'...
 !S!Abriendo nivel "%s"...
 !I!Apertura livello "%s"...
 !F!Ouverture niveau '%s'...
@@ -3987,14 +3987,14 @@
 !G!Level-Auswahl
 !S!Seleccionar nivel
 !I!Seleziona livello
-!F!sélection du niveau
+!F!sï¿½lection du niveau
 
 !/!562: Window text for level select
 !=!Start level(1 to %d)
 !G!Startlevel(1 bis %d)
 !S!Nivel inicial (1 a %d)
 !I!Livello iniziale (da 1 a %d)
-!F!Démarrer niveau (1 à %d)
+!F!Dï¿½marrer niveau (1 ï¿½ %d)
 
 !/!563: Level warp dialog title
 !=!Level Warp
@@ -4008,18 +4008,18 @@
 !G!Zum Level springen (1 bis %d)
 !S!Saltar a nivel(1 a %d)
 !I!Salta a livello (da 1 a %d)
-!F!Aller au niveau (1 à %d)
+!F!Aller au niveau (1 ï¿½ %d)
 
 !/!565: hotspot for select (choose, ok, etc.)
 !=!Select
-!G!Auswählen
+!G!Auswï¿½hlen
 !S!Seleccionar
 !I!Seleziona
-!F!Sélectionner
+!F!Sï¿½lectionner
 
 !/!566: Message displayed if the requested level is not valid
 !=!Please choose a level between 1 and %d.
-!G!Bitte einen Level zwischen 1 und %d auswählen.
+!G!Bitte einen Level zwischen 1 und %d auswï¿½hlen.
 !S!Elige un nivel entre 1 y %d.
 !I!Scegli un livello tra 1 e %d.
 !F!Choisissez un niveau entre 1 et %d.
@@ -4027,16 +4027,16 @@
 !/!567: The specified mission file was not found
 !=!Mission file not found.
 !G!Missionsdatei nicht gefunden.
-!S!No se encuentra archivo de misión
+!S!No se encuentra archivo de misiï¿½n
 !I!File della missione non trovato.
-!F!Fichier de mission non trouvé.
+!F!Fichier de mission non trouvï¿½.
 
 !/!568: Dedicated server message displayed during level load, progress indicator
 !=!%s %.0f Percent Complete
 !G!%s %.0f Prozent geladen
 !S!%s %.0f del total completo
 !I!%s %.0f del totale completato
-!F!%s %.0f Pourcent Chargé
+!F!%s %.0f Pourcent Chargï¿½
 
 !/!569: Load level progress indicator for rooms loaded
 !=!Initializing on-board computer
@@ -4050,63 +4050,63 @@
 !G!Verifiziere Waffensysteme 
 !S!Comprobando sistemas de armas
 !I!Verifica dei sistemi di armi
-!F!vérification des systèmes d'armes
+!F!vï¿½rification des systï¿½mes d'armes
 
 !/!571: Load level progress indicator for paging in data
 !=!Analyzing data...
 !G!Analysiere Daten...
 !S!Analizando datos...
 !I!Analisi dei dati...
-!F!Analyse des données...
+!F!Analyse des donnï¿½es...
 
 !/!572: Dedicated server message when the mission is over and it starts looping it
 !=!Mission over.  Looping back to first level in mission file.
-!G!Mission beendet. Zurück zum ersten Level in Missionsdatei.
-!S!Misión concluida. Volviendo al primer nivel del archivo de misión.
+!G!Mission beendet. Zurï¿½ck zum ersten Level in Missionsdatei.
+!S!Misiï¿½n concluida. Volviendo al primer nivel del archivo de misiï¿½n.
 !I!Missione conclusa. Ritorno al primo livello del file della missione.
-!F!Mission terminée. Retour au premier niveau dans le fichier mission.
+!F!Mission terminï¿½e. Retour au premier niveau dans le fichier mission.
 
 !/!573: Load level progress indicator for script loaded
 !=!Level script loaded
 !G!Levelskript geladen
-!S!Guión de nivel cargado
+!S!Guiï¿½n de nivel cargado
 !I!Procedura livello caricata
-!F!Script de niveau chargé
+!F!Script de niveau chargï¿½
 
 !/!574: Load level progress indicator for terrain loaded
 !=!Verifying propulsion systems
-!G!Überprüfe Antriebssysteme
-!S!Comprobando sistemas de propulsión
+!G!ï¿½berprï¿½fe Antriebssysteme
+!S!Comprobando sistemas de propulsiï¿½n
 !I!Verifica dei sistemi di propulsione
-!F!vérification des systèmes de propulsion
+!F!vï¿½rification des systï¿½mes de propulsion
 
 !/!575: Mission download status window title
 !=!Download Status
 !G!Status herunterladen
 !S!Estado de la descarga
 !I!Stato dello scaricamento
-!F!Statut du téléchargement
+!F!Statut du tï¿½lï¿½chargement
 
 !/!576: In multiplayer game, shows screen that data is corrupt and it's exiting
 !=!Network data corruption detected.
 !G!Netzwerkdatenkorruption entdeckt.
 !S!Detectado error de datos de red.
 !I!Dati di rete danneggiati
-!F!Corruption des données de réseau détectée.
+!F!Corruption des donnï¿½es de rï¿½seau dï¿½tectï¿½e.
 
 !/!577: In multiplayer, if joining the level the server changed levels
 !=!Server changed levels.
-!G!Server änderte Levels.
+!G!Server ï¿½nderte Levels.
 !S!El servidor ha cambiado de nivel.
 !I!Il server ha modificato i livelli.
-!F!Le serveur a changé les niveaux.
+!F!Le serveur a changï¿½ les niveaux.
 
 !/!578: continuation of rejoin message
 !=!Please try rejoining.
 !G!Bitte versuchen Sie erneut teilzunehmen.
 !S!Intenta volver a unirte a la partida.
 !I!Prova a ricollegarti.
-!F!Veuillez réessayez de joindre la partie.
+!F!Veuillez rï¿½essayez de joindre la partie.
 
 !/!579: Dedicated server message displayed when ending the level
 !=!Ending level.
@@ -4117,17 +4117,17 @@
 
 !/!580: Multiplayer message if a corrupted object
 !=!Corrupted object received.
-!G!Beschädigtes Objekt empfangen.
+!G!Beschï¿½digtes Objekt empfangen.
 !S!Objeto deteriorado recibido.
 !I!Ricevuto oggetto danneggiato.
-!F!Elément corrompu reçu.
+!F!Elï¿½ment corrompu reï¿½u.
 
 !/!581: Hud message if you attempt to go into observer mode and you don't have enough shields
 !=!Not enough shields to set observer.
-!G!Nicht genug Schutzschilde für Beobachtermodus.
+!G!Nicht genug Schutzschilde fï¿½r Beobachtermodus.
 !S!No hay suficientes escudos para ir a modo observador.
 !I!Scudi insufficienti per impostare l'osservatore.
-!F!Vous n'avez pas assez de boucliers pour être observateur.
+!F!Vous n'avez pas assez de boucliers pour ï¿½tre observateur.
 
 !/!582: Multiplayer progress screen when connecting
 !=!Connecting...
@@ -4147,27 +4147,27 @@
 !=!You already have the Vauss
 !G!Sie haben die Vausskanone schon
 !S!Ya tienes el Vauss
-!I!Hai già il Vauss
-!F!Vous avez déjà le Vauss.
+!I!Hai giï¿½ il Vauss
+!F!Vous avez dï¿½jï¿½ le Vauss.
 
 !/!585: Hud message when you pickup the vauss
 !=!Vauss!
 !G!Vauss!
-!S!¡Vauss!
+!S!ï¿½Vauss!
 !I!Vauss!
 !F!Vauss !
 
 !/!586: Hud message if you already have napalm
 !=!You already have the Napalm Gun
 !G!Sie haben die Napalmkanone schon 
-!S!Ya tienes el cañón de napalm
-!I!Hai già il cannone al napalm!
-!F!Vous avez déjà le Canon Napalm.
+!S!Ya tienes el caï¿½ï¿½n de napalm
+!I!Hai giï¿½ il cannone al napalm!
+!F!Vous avez dï¿½jï¿½ le Canon Napalm.
 
 !/!587: message when you pickup napalm
 !=!Napalm Gun!
 !G!Napalmkanone!
-!S!¡Cañón de napalm!
+!S!ï¿½Caï¿½ï¿½n de napalm!
 !I!Cannone al napalm!
 !F!Canon Napalm !
 
@@ -4175,27 +4175,27 @@
 !=!You already have the EMD Launcher
 !G!Sie haben die EMD-Kanone schon
 !S!Ya tienes el IEM
-!I!Hai già il lanciatore distruttore elettromagnetico (EMD)
-!F!Vous avez déjà le Lanceur DEM.
+!I!Hai giï¿½ il lanciatore distruttore elettromagnetico (EMD)
+!F!Vous avez dï¿½jï¿½ le Lanceur DEM.
 
 !/!589: Message when you pickup emd
 !=!EMD Launcher!
 !G!EMD-Kanone!
-!S!¡Interruptor EM!
+!S!ï¿½Interruptor EM!
 !I!Lanciatore EMD!
 !F!Lanceur DEM !
 
 !/!590: message if you already have microwave
 !=!You already have the Microwave Cannon
 !G!Sie haben die Mikrowellenkanone schon
-!S!Ya tienes el cañón de microondas
-!I!Hai già il cannone a microonde
-!F!Vous avez déjà le Canon Micro-Ondes.
+!S!Ya tienes el caï¿½ï¿½n de microondas
+!I!Hai giï¿½ il cannone a microonde
+!F!Vous avez dï¿½jï¿½ le Canon Micro-Ondes.
 
 !/!591: message when you get microwave
 !=!Microwave Cannon!
 !G!Mikrowellenkanone!
-!S!¡Cañón de microondas!
+!S!ï¿½Caï¿½ï¿½n de microondas!
 !I!Cannone a microonde!
 !F!Canon Micro-Ondes !
 
@@ -4203,239 +4203,239 @@
 !=!You already have the Mass Driver
 !G!Sie haben den Massetreiber schon
 !S!Ya tienes el Lanzamasa
-!I!Hai già il lanciamassa
-!F!Vous avez déjà le Canon à Particules.
+!I!Hai giï¿½ il lanciamassa
+!F!Vous avez dï¿½jï¿½ le Canon ï¿½ Particules.
 
 !/!593: message when you pickup mass driver
 !=!Mass Driver!
 !G!Massetreiber!
-!S!¡Lanzamasa!
+!S!ï¿½Lanzamasa!
 !I!Lanciamassa!
-!F!Canon à Particule !
+!F!Canon ï¿½ Particule !
 
 !/!594: message if you already have super laser
 !=!You already have the Super Laser
 !G!Sie haben den Superlaser schon
-!S!Ya tienes el superláser
-!I!Hai già il Super Laser
-!F!Vous avez déjà le Super Laser.
+!S!Ya tienes el superlï¿½ser
+!I!Hai giï¿½ il Super Laser
+!F!Vous avez dï¿½jï¿½ le Super Laser.
 
 !/!595: message when you pickup super laser
 !=!Super Laser!
 !G!Superlaser!
-!S!¡Superláser!
+!S!ï¿½Superlï¿½ser!
 !I!Super Laser!
 !F!Super Laser !
 
 !/!596: message if you already have plasma
 !=!You already have the Plasma Cannon
 !G!Sie haben die Plasmakanone schon
-!S!Ya tienes el cañón de plasma
-!I!Hai già il Cannone Plasma
-!F!Vous avez déjà le Canon Plasma.
+!S!Ya tienes el caï¿½ï¿½n de plasma
+!I!Hai giï¿½ il Cannone Plasma
+!F!Vous avez dï¿½jï¿½ le Canon Plasma.
 
 !/!597: message if you get plasma
 !=!Plasma Cannon!
 !G!Plasmakanone!
-!S!¡Cañón de plasma!
+!S!ï¿½Caï¿½ï¿½n de plasma!
 !I!Cannone plasma!
 !F!Canon Plasma !
 
 !/!598: message if you already have fusion
 !=!You already have the Fusion Cannon
 !G!Sie haben die Fusionskanone bereits
-!S!Ya tienes el cañón de fusión
-!I!Hai già il Cannone Fusione
-!F!Vous avez déjà le Canon à Fusion.
+!S!Ya tienes el caï¿½ï¿½n de fusiï¿½n
+!I!Hai giï¿½ il Cannone Fusione
+!F!Vous avez dï¿½jï¿½ le Canon ï¿½ Fusion.
 
 !/!599: message when you get fusion
 !=!Fusion Cannon!
 !G!Fusionskanone!
-!S!¡Cañón de fusión!
+!S!ï¿½Caï¿½ï¿½n de fusiï¿½n!
 !I!Cannone fusione!
-!F!Canon à Fusion !
+!F!Canon ï¿½ Fusion !
 
 !/!600: message when you already have omega
 !=!You already have the Omega Cannon
 !G!Sie haben die Omega-Kanone schon
-!S!Ya tienes el cañón Omega
-!I!Hai già il Cannone Omega
-!F!Vous avez déjà le Canon Oméga.
+!S!Ya tienes el caï¿½ï¿½n Omega
+!I!Hai giï¿½ il Cannone Omega
+!F!Vous avez dï¿½jï¿½ le Canon Omï¿½ga.
 
 !/!601: message when you pickup omega
 !=!Omega Cannon!
 !G!Omega-Kanone!
-!S!¡Cañón Omega!
+!S!ï¿½Caï¿½ï¿½n Omega!
 !I!Cannone Omega!
-!F!Canon Oméga !
+!F!Canon Omï¿½ga !
 
 !/!602: message when you pickup frag
 !=!Frag Missile!
 !G!Fragmentgeschoss!
-!S!¡Misil fragmentario!
+!S!ï¿½Misil fragmentario!
 !I!Missile Frammentatore!
 !F!Missile Frag !
 
 !/!603: message when frags are full
 !=!Frag Missiles Full
 !G!Fragmentgeschoss voll
-!S!Misiles fragmentarios al máximo
+!S!Misiles fragmentarios al mï¿½ximo
 !I!Missili frammentatori al massimo
 !F!Missiles Frag au maximum
 
 !/!604: message when you get an impact mortar
 !=!Impact Mortar!
 !G!Granatwerfer!
-!S!¡Mortero de impacto!
+!S!ï¿½Mortero de impacto!
 !I!Mortaio d'impatto!
 !F!Mortier d'impact !
 
 !/!605: message when impact mortars are full
 !=!Impact Mortars Full
 !G!Granatwerfer voll
-!S!Morteros de impacto al máximo
+!S!Morteros de impacto al mï¿½ximo
 !I!Mortai d'impatto al massimo
 !F!Mortiers d'impact au maximum
 
 !/!606: message when you get a napalm rocket
 !=!Napalm Rocket!
 !G!Napalmrakete!
-!S!¡Misil de napalm!
+!S!ï¿½Misil de napalm!
 !I!Razzo Napalm!
 !F!Rocket Napalm !
 
 !/!607: message when napalm rockets are full
 !=!Napalm Rockets Full
 !G!Napalmrakete voll
-!S!Misiles de napalm al máximo
+!S!Misiles de napalm al mï¿½ximo
 !I!Razzi Napalm al massimo
 !F!Roquettes Napalm au maximum
 
 !/!608: message when you get a cyclone
 !=!Cyclone Missile!
 !G!Zyklon-Geschoss!
-!S!¡Misil ciclón!
+!S!ï¿½Misil ciclï¿½n!
 !I!Missile Ciclone!
 !F!Missile Cyclone !
 
 !/!609: message when cyclones are full
 !=!Cyclone Missiles Full
 !G!Zyklon-Geschoss voll
-!S!Misiles ciclón al máximo
+!S!Misiles ciclï¿½n al mï¿½ximo
 !I!Missili Ciclone al massimo
 !F!Missile Cyclone au maximum
 
 !/!610: message when you pickup a blackshark
 !=!Black Shark Missile!
 !G!Black Shark Geschoss!
-!S!¡Misil Tiburón negro!
+!S!ï¿½Misil Tiburï¿½n negro!
 !I!Missile Squalo nero!
 !F!Missile Requin Noir !
 
 !/!611: message when black sharks are full
 !=!Black Shark Missiles Full
 !G!Black Shark Geschoss voll
-!S!Misiles Tiburón negro al máximo
+!S!Misiles Tiburï¿½n negro al mï¿½ximo
 !I!Missili Squalo nero al massimo
 !F!Missiles Requin Noir au maximum
 
 !/!612: message when you pickup a concussion
 !=!Concussion Missile!
-!G!Erschütterungsgeschoss!
-!S!¡Cohete S-1!
+!G!Erschï¿½tterungsgeschoss!
+!S!ï¿½Cohete S-1!
 !I!Missile esplosivo!
-!F!Missile à explosion !
+!F!Missile ï¿½ explosion !
 
 !/!613: message when concussion missiles are full
 !=!Concussion Missiles Full
-!G!Erschütterungsgeschoss voll
-!S!Cohetes S-1 al máximo
+!G!Erschï¿½tterungsgeschoss voll
+!S!Cohetes S-1 al mï¿½ximo
 !I!Missili esplosivi al massimo
-!F!Missiles à explosion au maximum
+!F!Missiles ï¿½ explosion au maximum
 
 !/!614: message when you get a homer
 !=!Homing Missile!
 !G!Zielpeilgeschoss!
-!S!¡Misil buscador!
+!S!ï¿½Misil buscador!
 !I!Missile autoguidato!
-!F!Missile autoguidés !
+!F!Missile autoguidï¿½s !
 
 !/!615: message when homing missiles are full
 !=!Homing Missiles Full
 !G!Zielpeilgeschoss voll
-!S!Misiles buscadores al máximo
+!S!Misiles buscadores al mï¿½ximo
 !I!Missili autoguidati al massimo
-!F!Missiles autoguidés au maximum
+!F!Missiles autoguidï¿½s au maximum
 
 !/!616: message when you pickup a smart missile
 !=!Smart Missile!
 !G!Smart-Geschoss!
-!S!¡Misil inteligente!
+!S!ï¿½Misil inteligente!
 !I!Missile intelligente!
 !F!Missile Smart !
 
 !/!617: message when smarts are full
 !=!Smart Missiles Full
 !G!Smart-Geschoss voll
-!S!Misiles inteligentes al máximo
+!S!Misiles inteligentes al mï¿½ximo
 !I!Missili intelligenti al massimo
 !F!Missiles Smart au maximum
 
 !/!618: message when you pickup a mega
 !=!Mega Missile!
 !G!Mega-Geschoss!
-!S!¡Megamisil!
+!S!ï¿½Megamisil!
 !I!Mega Missile!
-!F!Missile Méga !
+!F!Missile Mï¿½ga !
 
 !/!619: message when megas are full
 !=!Mega Missiles Full
 !G!Mega-Geschoss voll
-!S!Megamisiles al máximo
+!S!Megamisiles al mï¿½ximo
 !I!Mega Missili al massimo
-!F!Missiles Méga au maximum
+!F!Missiles Mï¿½ga au maximum
 
 !/!620: message when you pickup a guided
 !=!Guided Missile!
 !G!Fernlenkgeschoss!
-!S!¡Misil guiado!
+!S!ï¿½Misil guiado!
 !I!Missile teleguidato!
-!F!Missile guidé !
+!F!Missile guidï¿½ !
 
 !/!621: message when guideds are full
 !=!Guided Missiles Full
 !G!Fernlenkgeschoss voll
-!S!Misiles guiados al máximo
+!S!Misiles guiados al mï¿½ximo
 !I!Missili teleguidati al massimo
-!F!Missiles guidés au maximum
+!F!Missiles guidï¿½s au maximum
 
 !/!622: format for multiple homing missiles pickup
 !=!%d Homing Missiles!
 !G!%d Zielpeilgeschosse!
-!S!¡%d misiles buscadores!
+!S!ï¿½%d misiles buscadores!
 !I!%d missili autoguidati!
-!F!%d missiles autoguidés !
+!F!%d missiles autoguidï¿½s !
 
 !/!623: format message when you pickup multiple concussions
 !=!%d Concussion Missiles!
-!G!%d Erschütterungsgeschosse!
-!S!¡%d cohetes S-1!
+!G!%d Erschï¿½tterungsgeschosse!
+!S!ï¿½%d cohetes S-1!
 !I!%d missili esplosivi!
-!F!%d missiles à explosion !
+!F!%d missiles ï¿½ explosion !
 
 !/!624: message when you pickup multiple frag missiles
 !=!%d Frag Missiles!
 !G!%d Fragmentgeschosse!
-!S!¡%d misiles de fragmentarios!
+!S!ï¿½%d misiles de fragmentarios!
 !I!%d missili frammentatori!
 !F!%d missiles Frag !
 
 !/!625: message when you pickup multiple guided missiles
 !=!%d Guided Missiles!
 !G!%d Fernlenkgeschosse!
-!S!¡%d misiles guiados!
+!S!ï¿½%d misiles guiados!
 !I!%d missili teleguidati!
-!F!%d missiles guidés !
+!F!%d missiles guidï¿½s !
 
 !/!626: message when you pickup some vauss ammo
 !=!%d Vauss rounds
@@ -4447,7 +4447,7 @@
 !/!627: message when the vauss cannon is full
 !=!Vauss Cannon full
 !G!Vausskanone voll
-!S!Cañón Vauss al máximo
+!S!Caï¿½ï¿½n Vauss al mï¿½ximo
 !I!Cannone Vauss al massimo
 !F!Canon Vauss plein
 
@@ -4456,14 +4456,14 @@
 !G!%d Massetreiberrunden
 !S!%d disparos de Lanzamasa
 !I!%d spari del lanciamassa
-!F!%d balles de canon à particules
+!F!%d balles de canon ï¿½ particules
 
 !/!629: message when massdriver is full
 !=!Mass Driver full
 !G!Massetreiber voll
-!S!Lanzamasa al máximo
+!S!Lanzamasa al mï¿½ximo
 !I!Lanciamassa al massimo
-!F!Canon à particules plein
+!F!Canon ï¿½ particules plein
 
 !/!630: message when you pickup napalm full (12.50 liters of Napalm fuel for example)
 !=!%d.%d liters of Napalm fuel
@@ -4475,7 +4475,7 @@
 !/!631: message when napalm cannon is full
 !=!Napalm Cannon full
 !G!Napalmkanone voll
-!S!Cañón de napalm al máximo
+!S!Caï¿½ï¿½n de napalm al mï¿½ximo
 !I!Cannone Napalm al massimo
 !F!Canon Napalm plein
 
@@ -4483,132 +4483,132 @@
 !=!Invulnerability Off
 !G!Unverwundbarkeit Aus
 !S!Invulnerabilidad desactivada
-!I!Invulnerabilità disattivata
-!F!Invulnérabilité désactivée
+!I!Invulnerabilitï¿½ disattivata
+!F!Invulnï¿½rabilitï¿½ dï¿½sactivï¿½e
 
 !/!633: Hud message when cloak wears off
 !=!Cloak off
 !G!Tarnung aus
 !S!Camuflaje desactivado
-!I!Disattivata invisibilità
-!F!A découvert
+!I!Disattivata invisibilitï¿½
+!F!A dï¿½couvert
 
 !/!634: hud message when cloak wears off
 !=!Cloak Off
 !G!Tarnung aus
 !S!Camuflaje desactivado
-!I!Disattivata invisibilità
-!F!A découvert
+!I!Disattivata invisibilitï¿½
+!F!A dï¿½couvert
 
 !/!635: hud message if you are full shields
 !=!Shields Full
 !G!Schutzschilde voll
-!S!Escudos al máximo
+!S!Escudos al mï¿½ximo
 !I!Scudi al massimo
 !F!Boucliers au maximum
 
 !/!636: hud message when your shields are boosted
 !=!Shields boosted to %d
-!G!Schutzschilde auf %d erhöht
+!G!Schutzschilde auf %d erhï¿½ht
 !S!Escudos cargados a %d
 !I!Scudi caricati a %d
-!F!Boucliers renforcés à %d
+!F!Boucliers renforcï¿½s ï¿½ %d
 
 !/!637: hud message when you pickup energy
 !=!Energy!
 !G!Energie!
-!S!¡Energía!
+!S!ï¿½Energï¿½a!
 !I!Energia!
 !F!Energie !
 
 !/!638: hud message when you pickup quad lasers
 !=!Quad Lasers!
 !G!Quadrolaser!
-!S!¡Lásers cuádruples!
+!S!ï¿½Lï¿½sers cuï¿½druples!
 !I!Laser quadrupli!
 !F!Lasers Quad !
 
 !/!639: hud message if you already have quad laser
 !=!You already have Quad Lasers
 !G!Sie haben schon Quadrolaser 
-!S!Ya tienes lásers cuádruples
-!I!Hai già i laser quadrupli
-!F!Vous avez déjà les Lasers Quad
+!S!Ya tienes lï¿½sers cuï¿½druples
+!I!Hai giï¿½ i laser quadrupli
+!F!Vous avez dï¿½jï¿½ les Lasers Quad
 
 !/!640: hud message when you pickup invulnerability
 !=!Invulnerability On
 !G!Unverwundbarkeit ein
 !S!Invulnerabilidad activada
-!I!Invulnerabilità attivata
-!F!Invulnérabilité Activée
+!I!Invulnerabilitï¿½ attivata
+!F!Invulnï¿½rabilitï¿½ Activï¿½e
 
 !/!641: hud message if you are already invulnerable
 !=!You're already invulnerable
 !G!Sie sind bereits unverwundbar
 !S!Ya eres invulnerable
-!I!Sei già invulnerabile
-!F!Vous êtes déjà invulnérable.
+!I!Sei giï¿½ invulnerabile
+!F!Vous ï¿½tes dï¿½jï¿½ invulnï¿½rable.
 
 !/!642: hud message when you pickup cloak
 !=!Cloak On
 !G!Tarnung ein
 !S!Camuflaje activado
-!I!Attivata invisibilità
-!F!Camouflage Activé
+!I!Attivata invisibilitï¿½
+!F!Camouflage Activï¿½
 
 !/!643: hud message when you are already cloaked
 !=!Already cloaked
 !G!Sie sind bereits getarnt
-!S!Ya estás camuflajeado
-!I!Sei già invisibile
-!F!Déjà occulté
+!S!Ya estï¿½s camuflajeado
+!I!Sei giï¿½ invisibile
+!F!Dï¿½jï¿½ occultï¿½
 
 !/!644: hud message when you pickup chaff
 !=!Chaff
-!G!Störspreu
-!S!Señuelos
+!G!Stï¿½rspreu
+!S!Seï¿½uelos
 !I!Sberleffo
 !F!Chaff
 
 !/!645: hud message when you pickup mutliple chaffs
 !=!%d Chaff Packs
-!G!%d Störspreupakete
-!S!%d Paquetes de señuelos
+!G!%d Stï¿½rspreupakete
+!S!%d Paquetes de seï¿½uelos
 !I!%d pacchetti di sberleffi
 !F!%d paquets de Chaff
 
 !/!646: hud message if your counter measure inventory is full
 !=!Countermeasures Full
 !G!Gegenmassnahmen voll
-!S!Contramedidas al máximo
+!S!Contramedidas al mï¿½ximo
 !I!Contromisure al massimo
 !F!Leurres au Maximum
 
 !/!647: hud message if your chaffs are full
 !=!You Can't Carry Any More Chaff Packets
-!G!Sie können keine weiteren Störspreupakete aufnehmen
-!S!No puedes llevar más paquetes de señuelos
+!G!Sie kï¿½nnen keine weiteren Stï¿½rspreupakete aufnehmen
+!S!No puedes llevar mï¿½s paquetes de seï¿½uelos
 !I!Non puoi trasportare altri pacchetti di sberleffi
 !F!Impossible de transporter plus de Chaff.
 
 !/!648: hud message when you pickup a betty
 !=!Bouncing Betty
-!G!Hüpfende Betty
+!G!Hï¿½pfende Betty
 !S!Betty
 !I!Betty
 !F!Betty
 
 !/!649: hud message when you pickup multiple bettys
 !=!%d Bouncing Bettys
-!G!%d Hüpfende Bettys
+!G!%d Hï¿½pfende Bettys
 !S!%d Bettys
 !I!%d Betty
 !F!%d Bettys
 
 !/!650: hud message when you can't carry anymore bettys
 !=!You Can't Carry Any More Bettys
-!G!Sie können keine weiteren Hüpfende Bettys aufnehmen
-!S!No puedes llevar más Bettys
+!G!Sie kï¿½nnen keine weiteren Hï¿½pfende Bettys aufnehmen
+!S!No puedes llevar mï¿½s Bettys
 !I!Non puoi trasportare altre Betty
 !F!Impossible de transporter plus de Bettys.
 
@@ -4628,8 +4628,8 @@
 
 !/!653: message when your seekers are full
 !=!You Can't Carry Any More Seeker Mines
-!G!Sie können keine weiteren Sucherminen aufnehmen
-!S!No puedes llevar más minas buscadoras
+!G!Sie kï¿½nnen keine weiteren Sucherminen aufnehmen
+!S!No puedes llevar mï¿½s minas buscadoras
 !I!Non puoi trasportare altre mine cercatrici
 !F!Impossible de transporter plus de mines chercheuses.
 
@@ -4649,84 +4649,84 @@
 
 !/!656: message when gunboys are full
 !=!You Can't Carry Any More GunBoys
-!G!Sie können keine weiteren GunBoys aufnehmen
-!S!No puedes llevar más Robofusiles
+!G!Sie kï¿½nnen keine weiteren GunBoys aufnehmen
+!S!No puedes llevar mï¿½s Robofusiles
 !I!Non puoi trasportare altri GunBoy
 !F!Impossible de transporter plus de GunBoys
 
 !/!657: hud message when you pickup an afterburner cooler
 !=!Afterburner Cooler!
-!G!Nachbrenner-Kühler!
-!S!¡Refrigerador de postcombustión!
+!G!Nachbrenner-Kï¿½hler!
+!S!ï¿½Refrigerador de postcombustiï¿½n!
 !I!Refrigeratore del postcombustore!
 !F!Refroidissant Postcombustion !
 
 !/!658: hud message if you already have an afterburner cooler
 !=!You Already Have An Afterburner Cooler
-!G!Sie haben schon einen Nachbrenner-Kühler
-!S!Ya tienes un refrigerador de postcombustión
-!I!Hai già un refrigeratore del postcombustore
-!F!Vous avez déjà un refroidissant de postcombution.
+!G!Sie haben schon einen Nachbrenner-Kï¿½hler
+!S!Ya tienes un refrigerador de postcombustiï¿½n
+!I!Hai giï¿½ un refrigeratore del postcombustore
+!F!Vous avez dï¿½jï¿½ un refroidissant de postcombution.
 
 !/!659: message when you pickup an energy to shields converter
 !=!Energy-to-Shields Converter!
 !G!Energie-zu-Schutzschild-Umformer!
-!S!¡Convertidor de energía a escudos!
+!S!ï¿½Convertidor de energï¿½a a escudos!
 !I!Convertitore di energia in scudi!
 !F!Convertisseur d'energie en bouclier !
 
 !/!660: message when you already have an energy to shields conv
 !=!You Already Have A Energy-to-Shields Converter
 !G!Sie haben bereits einen Energie-zu-Schutzschild-Umformer
-!S!Ya tienes un convertidor de energía a escudos
-!I!Hai già un convertitore di energia in scudi
-!F!Vous avez déjà un convertisseur d'energie en bouclier.
+!S!Ya tienes un convertidor de energï¿½a a escudos
+!I!Hai giï¿½ un convertitore di energia in scudi
+!F!Vous avez dï¿½jï¿½ un convertisseur d'energie en bouclier.
 
 !/!661: hud message when you pickup full automap powerup
 !=!Full Map!
 !G!Komplette Karte!
-!S!¡Mapa completo!
+!S!ï¿½Mapa completo!
 !I!Mappa completa!
-!F!Carte entière !
+!F!Carte entiï¿½re !
 
 !/!662: In file dialog, message that pops up while building file list
 !=!Getting Files...
 !G!Erhalte Dateien...
 !S!Obteniendo archivos...
 !I!Ricezione file...
-!F!Récupération des fichiers...
+!F!Rï¿½cupï¿½ration des fichiers...
 
 !/!663: hud message report for time-demo
 !=!Timedemo reports %.2f FPS
 !G!Zeitdemo Report %.2f FPS 
-!S!Demostración reporta %.2f FPS 
+!S!Demostraciï¿½n reporta %.2f FPS 
 !I!Rapporti demo tempi %.2f FPS
-!F!Temps de Démo affiche %.2f FPS
+!F!Temps de Dï¿½mo affiche %.2f FPS
 
 !/!664: hotspot label in pilot dialog
 !=!Add
-!G!Dazufügen
-!S!Añadir
+!G!Dazufï¿½gen
+!S!Aï¿½adir
 !I!Aggiungi
 !F!Ajouter
 
 !/!665: hotspot label in pilot dialog
 !=!Edit
-!G!Ändern
+!G!ï¿½ndern
 !S!Editar
 !I!Modifica
 !F!Modifier
 
 !/!666: in pilot dialog, message saying pilot file no longer exists
 !=!Pilot No Longer Exists. Please Select A New One.
-!G!Pilot existiert nicht mehr. Bitte neuen auswählen.
+!G!Pilot existiert nicht mehr. Bitte neuen auswï¿½hlen.
 !S!Este piloto ya no existe. Elige uno nuevo.
-!I!Il pilota non esiste più. Scegline uno nuovo.
+!I!Il pilota non esiste piï¿½. Scegline uno nuovo.
 !F!Pilote Inexistant. Choisissez-en un autre.
 
 !/!667: hotspot label for pilot picture selection
 !=!CHOOSE PILOT PICTURE
-!G!PILOTENBILD AUSWÄHLEN
+!G!PILOTENBILD AUSWï¿½HLEN
 !S!ELIGE FOTO DE PILOTO
 !I!SCEGLI FOTO PILOTA
 !F!CHOISIR PHOTO DU PILOTE
@@ -4734,20 +4734,20 @@
 !/!668: first line of copy controls instructions
 !=!From which do you want to
 !G!Welche Einstellungen
-!S!¿Desde dónde quieres copiar 
+!S!ï¿½Desde dï¿½nde quieres copiar 
 !I!Da dove desideri
-!F!D'où voulez-vous copier les
+!F!D'oï¿½ voulez-vous copier les
 
 !/!669: second line of copy controls instructions
 !=!copy control settings from?
 !G!sollen kopiert werden?
-!S!la configuración de control?
+!S!la configuraciï¿½n de control?
 !I!copiare la configurazione di controllo?
-!F!paramètres des commandes ?
+!F!paramï¿½tres des commandes ?
 
 !/!670: line 3 of the copy controls instructions
 !=!Click cancel for none.
-!G!Abbruch für keine.
+!G!Abbruch fï¿½r keine.
 !S!Cancelar para escoger despues.
 !I!Premi Annulla per nessuna selezione.
 !F!pour aucune copie, annulez.
@@ -4755,7 +4755,7 @@
 !/!671: import graphic hotspot in multiplayer ship config
 !=!Import Graphic
 !G!Grafik importieren
-!S!Importar gráfico
+!S!Importar grï¿½fico
 !I!Importa grafico
 !F!Importer graphisme
 
@@ -4776,14 +4776,14 @@
 !/!674: audio taunt 1 label
 !=!Audio Taunt #1
 !G!Audio-Hohn 1
-!S!Provocación nº 1
+!S!Provocaciï¿½n nï¿½ 1
 !I!Provocazione audio n. 1
 !F!Raillerie Audio #1
 
 !/!675: audio taunt 2 label
 !=!Audio Taunt #2
 !G!Audio-Hohn 2
-!S!Provocación nº 1
+!S!Provocaciï¿½n nï¿½ 1
 !I!Provocazione audio n. 2
 !F!Raillerie Audio #2
 
@@ -4796,64 +4796,64 @@
 
 !/!677: message displayed if they had selected a ship no longer available
 !=!The ship you have selected wasn't found. Using default.
-!G!Gewähltes Schiff nicht gefunden. Standard wird verwendet.
-!S!No se encuentra la nave elegida. Se utilizará la predeterminada.
-!I!La nave selezionata non è stata trovata. Verrà usata quella predefinita.
-!F!Vaisseau sélectionné non trouvé. Utilisation du vaisseau par défaut.
+!G!Gewï¿½hltes Schiff nicht gefunden. Standard wird verwendet.
+!S!No se encuentra la nave elegida. Se utilizarï¿½ la predeterminada.
+!I!La nave selezionata non ï¿½ stata trovata. Verrï¿½ usata quella predefinita.
+!F!Vaisseau sï¿½lectionnï¿½ non trouvï¿½. Utilisation du vaisseau par dï¿½faut.
 
 !/!678: audio taunt import error if the file size is bigger than 32K
 !=!Compressed file is larger than %dK.  It will not be transferred.
-!G!Komprimierte Datei ist grösser als %d K. Sie wird nicht übertragen.
-!S!El archivo compromido ocupa más de %d K. No se puede transferir.
-!I!Il file compresso è maggiore di %d Kb. Non sarà trasferito.
-!F!Le fichier compressé est plus grand que %dK. Il ne sera pas transféré.
+!G!Komprimierte Datei ist grï¿½sser als %d K. Sie wird nicht ï¿½bertragen.
+!S!El archivo compromido ocupa mï¿½s de %d K. No se puede transferir.
+!I!Il file compresso ï¿½ maggiore di %d Kb. Non sarï¿½ trasferito.
+!F!Le fichier compressï¿½ est plus grand que %dK. Il ne sera pas transfï¿½rï¿½.
 
 !/!679: message if audio import was successful
 !=!Audio File Imported
 !G!Audiodatei importiert
 !S!Archivo de sonido importado
 !I!File audio importato
-!F!Fichier Audio Importé
+!F!Fichier Audio Importï¿½
 
 !/!680: message during audio taunt, if it couldn't copy temp file
 !=!Unable to copy temp file
-!G!Temp-Datei kopieren nicht möglich
+!G!Temp-Datei kopieren nicht mï¿½glich
 !S!No se puede copiar archivo temporal
 !I!Impossibile copiare il file temporaneo
 !F!Copie du fichier temporaire impossible 
 
 !/!681: error message of taunt import
 !=!Unable to create CRC File
-!G!CRC-Datei erstellen nicht möglich
+!G!CRC-Datei erstellen nicht mï¿½glich
 !S!No se puede crear archivo CRC
 !I!Impossibile creare file CRC
-!F!Création du fichier CRC impossible 
+!F!Crï¿½ation du fichier CRC impossible 
 
 !/!682: error message if no pilot pictures are available to choose from (use \n to force a newline)
 !=!There are no available\npictures for this pilot
-!G!Es sind keine Bilder für\ndiesen Piloten verfügbar
-!S!No hay fotografías disponibles\npara este piloto
+!G!Es sind keine Bilder fï¿½r\ndiesen Piloten verfï¿½gbar
+!S!No hay fotografï¿½as disponibles\npara este piloto
 !I!Per questo pilota non\nci sono foto disponibili
 !F!Ce pilote n'a pas de\nphoto.
 
 !/!683: error creating dialog
 !=!An Error Occured Creating Dialog.
 !G!Fehler beim Dialog erstellen.
-!S!Error al crear cuadro de diálogo.
+!S!Error al crear cuadro de diï¿½logo.
 !I!Errore di creazione della finestra di dialogo.
-!F!Erreur à la création du dialogue.
+!F!Erreur ï¿½ la crï¿½ation du dialogue.
 
 !/!684: Pilot picture window label
 !=!Pilot Picture
 !G!Pilotenbild
-!S!Fotografía de piloto
+!S!Fotografï¿½a de piloto
 !I!Foto del pilota
 !F!Photo du pilote
 
 !/!685: pictures label in pilot pics dialog
 !=!Pictures
 !G!Bilder
-!S!Fotografías
+!S!Fotografï¿½as
 !I!Fotografie
 !F!Photos
 
@@ -4868,7 +4868,7 @@
 !=!Entering observer mode.
 !G!In Beobachter-Modus eintreten.
 !S!Entrando en modo observador.
-!I!Ingresso in modalità osservatore.
+!I!Ingresso in modalitï¿½ osservatore.
 !F!Passage en mode d'observation.
 
 !/!688: message when another player enters observer mode
@@ -4882,7 +4882,7 @@
 !=!Leaving observer mode.
 !G!Beobachter-Modus verlassen.
 !S!Saliendo del modo observador.
-!I!Uscita dalla modalità osservatore.
+!I!Uscita dalla modalitï¿½ osservatore.
 !F!Abandon du mode d'observation.
 
 !/!690: message when another player leaves observer mode
@@ -4894,17 +4894,17 @@
 
 !/!691: message if you don't have enough energy for energy->shields converter
 !=!Need more than %d energy to enable transfer
-!G!Es werden mehr als %d Energieeinheiten zum Umformen benötigt
-!S!Se necesita más de %d de energía para permitir la transferencia
-!I!Per il trasferimento è necessario più di %d energia
-!F!Il faut plus de %d en énergie pour permettre le transfert.
+!G!Es werden mehr als %d Energieeinheiten zum Umformen benï¿½tigt
+!S!Se necesita mï¿½s de %d de energï¿½a para permitir la transferencia
+!I!Per il trasferimento ï¿½ necessario piï¿½ di %d energia
+!F!Il faut plus de %d en ï¿½nergie pour permettre le transfert.
 
 !/!692: message when energy->shields doesn't continue because shields are full
 !=!No transfer: Shields already at max
 !G!Kein Transfer: Schutzschilde bereits maximiert
-!S!No hay transferencia: el escudo ya se encuentra al máximo
-!I!Trasferimento non effettuato: scudi già al massimo
-!F!Arrêt du transfert: boucliers déjà au maximum.
+!S!No hay transferencia: el escudo ya se encuentra al mï¿½ximo
+!I!Trasferimento non effettuato: scudi giï¿½ al massimo
+!F!Arrï¿½t du transfert: boucliers dï¿½jï¿½ au maximum.
 
 !/!693: TelCom Main menu briefings button
 !=!Briefings
@@ -4943,16 +4943,16 @@
 
 !/!698: instructions in automap to turn on/off terrain
 !=!F1 - Turn terrain %s    1 thru 8 - Markers
-!G!F1 - Gelände %s       1 bis 8 - Markierungen 
+!G!F1 - Gelï¿½nde %s       1 bis 8 - Markierungen 
 !S!F1: Girar terreno %s    1 a 8: marcadores 
 !I!F1: Terreno %s    da 1 a 8 - segnapunti
-!F!F1: regler terrain sur %s   1 à 8 - Marqueurs
+!F!F1: regler terrain sur %s   1 ï¿½ 8 - Marqueurs
 
 !/!699: more instructions for automap
 !=!F2 - Center on player   F3 - Realign to gravity
 !G!F2 - Auf Spieler zentrieren F3 - Schwerkraftausrichtung 
 !S!F2: Centrar en jugador F3: Realinear a gravedad
-!I!F2: Centra sul giocatore F3: Riallinea alla gravità
+!I!F2: Centra sul giocatore F3: Riallinea alla gravitï¿½
 !F!F2: centrage sur joueur  F3: realignement sur gravite
 
 !/!700: Ranks
@@ -4965,7 +4965,7 @@
 !/!701: Ranks
 !=!Ensign
 !G!Unteroffizier 
-!S!Alférez
+!S!Alfï¿½rez
 !I!Guardiamarina
 !F!Enseigne
 
@@ -4993,7 +4993,7 @@
 !/!705: Ranks
 !=!Captain
 !G!Hauptmann
-!S!Capitán
+!S!Capitï¿½n
 !I!Capitano
 !F!Capitaine
 
@@ -5021,7 +5021,7 @@
 !/!709: Ranks
 !=!Demigod
 !G!Halbgott
-!S!Semidiós
+!S!Semidiï¿½s
 !I!Semidio
 !F!Demi-dieu
 
@@ -5029,12 +5029,12 @@
 !=!has been
 !G!wurde
 !S!ha sido 
-!I!è stato
-!F!a été
+!I!ï¿½ stato
+!F!a ï¿½tï¿½
 
 !/!711: promoted to
 !=!promoted to
-!G!befördert zum
+!G!befï¿½rdert zum
 !S!ascendido a
 !I!promosso a
 !F!promu au grade de
@@ -5044,28 +5044,28 @@
 !G!degradiert zum
 !S!degradado a
 !I!degradato a
-!F!rétrogradé au grade de
+!F!rï¿½trogradï¿½ au grade de
 
 !/!713: Hud message when you get 1 prox mine
 !=!Prox Mine
 !G!Nahmine
 !S!Mina de proximidad
-!I!Mina di prossimità
+!I!Mina di prossimitï¿½
 !F!Mine Prox
 
 !/!714: Hud message displayed when you pickup multiple prox mines
 !=!%d Prox Mines
-!G!%d Annäherungsminen
+!G!%d Annï¿½herungsminen
 !S!%d minas de proximidad
 
-!I!%d mine di prossimità
+!I!%d mine di prossimitï¿½
 !F!%d Mines Prox
 
 !/!715: Hud message when prox mines are full
 !=!You Can't Carry Any More Prox Mines
-!G!Sie können keine weiteren Annäherungsminen aufnehmen
-!S!No puedes llevar más minas de proximidad
-!I!Non puoi portare altre mine di prossimità
+!G!Sie kï¿½nnen keine weiteren Annï¿½herungsminen aufnehmen
+!S!No puedes llevar mï¿½s minas de proximidad
+!I!Non puoi portare altre mine di prossimitï¿½
 !F!Vous ne pouvez pas transporter plus de mines Prox.
 
 !/!716: Play (used in new game dialog)
@@ -5092,9 +5092,9 @@
 !/!719: Detail settings for Geometry (used in details menu for the detail sliders.)
 !=!Geometry
 !G!Geometrie
-!S!Geometría
+!S!Geometrï¿½a
 !I!Geometria
-!F!Géométrie
+!F!Gï¿½omï¿½trie
 
 !/!720: Used in video config menu to specify screen gamma or vertical sync
 !=!Monitor options
@@ -5127,37 +5127,37 @@
 !/!724: Used to group items in controller/keyboard config menus
 !=!Thrusting
 !G!Schubkraft
-!S!Propulsión
+!S!Propulsiï¿½n
 !I!Spinta
 !F!propulsion
 
 !/!725: Used to group items in controller/keyboard config menus
 !=!Turning
 !G!Drehen
-!S!Rotación
+!S!Rotaciï¿½n
 !I!Rotazione
 !F!rotation
 
 !/!726:In keyboard config menu
 !=!Audio Taunt 1
 !G!Audio-Hohn 1
-!S!Provocación 1
+!S!Provocaciï¿½n 1
 !I!Provocazione audio 1
 !F!raillerie 1
 
 !/!727:In keyboard config menu
 !=!Audio Taunt 2
 !G!Audio-Hohn 2
-!S!Provocación 2
+!S!Provocaciï¿½n 2
 !I!Provocazione audio 2
 !F!raillerie 2
 
 !/!728:Used in controller config menus for rear view function
 !=!Rear View
-!G!Rückansicht
+!G!Rï¿½ckansicht
 !S!Vista trasera
 !I!Vista posteriore
-!F!vue arrière
+!F!vue arriï¿½re
 
 !/!729:Used in hud config menu
 !=!HUD Warnings
@@ -5169,7 +5169,7 @@
 !/!730:Used in missions dialog
 !=!Info
 !G!Infos
-!S!Información
+!S!Informaciï¿½n
 !I!Informazioni
 !F!infos
 
@@ -5197,7 +5197,7 @@
 !/!734:Help screen text
 !=!Shift-F9
 !G!Shift-F9
-!S!Mayús+F9
+!S!Mayï¿½s+F9
 !I!Maiusc+F9
 !F!Maj.+F9
 
@@ -5211,7 +5211,7 @@
 !/!736:Help screen text
 !=!Shift-F8
 !G!Shift-F8
-!S!Mayús+F8
+!S!Mayï¿½s+F8
 !I!Maiusc+F8
 !F!Maj.+F8
 
@@ -5241,40 +5241,40 @@
 !G!Doppelklicken Sie auf eine Zeile.
 !S!Selecciona una ranura en donde guardar la partida.
 !I!Fai doppio clic sullo slot o usa tasti freccia e premi INVIO.
-!F!Double-cliquez sur une case ou utilisez les touches fléchées et appuyez sur Entrée.
+!F!Double-cliquez sur une case ou utilisez les touches flï¿½chï¿½es et appuyez sur Entrï¿½e.
 
 !/!741:load game screen
 !=!Double click on slot or use arrow keys and press ENTER.
 !G!Doppelklicken Sie auf eine Zeile.
 !S!Selecciona una ranura de donde cargar la partida.
 !I!Fai doppio clic sullo slot o usa tasti freccia e premi INVIO.
-!F!Double-cliquez sur une case ou utilisez les touches fléchées et appuyez sur Entrée.
+!F!Double-cliquez sur une case ou utilisez les touches flï¿½chï¿½es et appuyez sur Entrï¿½e.
  
 !/!742:save game screen
 !=!There is already a saved game of that name. Please choose another.
-!G!Gespeichertes Spiel mit diesem Namen bereits vorhanden. Bitte einen anderen auswählen.
+!G!Gespeichertes Spiel mit diesem Namen bereits vorhanden. Bitte einen anderen auswï¿½hlen.
 !S!Ya hay un juego guardado con ese nombre. Elige otro.
-!I!Esiste già una partita salvata con questo nome. Scegline un'altra.
-!F!Ce nom de sauvegarde existe déjà. Choisissez-en un autre.
+!I!Esiste giï¿½ una partita salvata con questo nome. Scegline un'altra.
+!F!Ce nom de sauvegarde existe dï¿½jï¿½. Choisissez-en un autre.
 
 !/!743:save game screen
 !=!Overwrite current saved game?
-!G!Gespeichertes Spiel überschreiben?
-!S!¿Sustituir partida guardada?
+!G!Gespeichertes Spiel ï¿½berschreiben?
+!S!ï¿½Sustituir partida guardada?
 !I!Sovrascrivere la partita salvata?
-!F!Ecraser la dernière sauvegarde ?
+!F!Ecraser la derniï¿½re sauvegarde ?
 
 !/!744:used in general config menu and joystick settings menu
 !=!Input Devices
 !G!Steuerelemente
 !S!Dispositivos de entrada
 !I!Dispositivi di input
-!F!Périphériques
+!F!Pï¿½riphï¿½riques
 
 !/!745: help dialog text
 !=!Shift-Tab
 !G!Shift-Tab 
-!S!Mayús+Tab
+!S!Mayï¿½s+Tab
 !I!Maiusc+Tab
 !F!Maj.-Tab
 
@@ -5290,75 +5290,75 @@
 !G!Beim Erstellen der Pilotendatei trat ein Dateischreibfehler auf.
 !S!Se ha producido un error de escritura al intentar crear el archivo del piloto.
 !I!Errore di scrittura file durante la creazione del file del pilota.
-!F!Erreur d'écriture lors de la création du fichier Pilote.
+!F!Erreur d'ï¿½criture lors de la crï¿½ation du fichier Pilote.
 
 !/!748: pilot write error
 !=!There was an internal error trying to create the Pilot file.
 !G!Beim Erstellen der Pilotendatei trat ein interner Fehler auf.
 !S!Se ha producido un error interno al intentar crear el archivo del piloto.
 !I!Errore interno durante la creazione del file del pilota.
-!F!Une erreur interne est survenue lors de la création du fichier Pilote.
+!F!Une erreur interne est survenue lors de la crï¿½ation du fichier Pilote.
 
 !/!749:In keyboard config menu
 !=!Audio Taunt 3
 !G!Audio-Hohn 3
-!S!Provocación 3
+!S!Provocaciï¿½n 3
 !I!Provocazione audio 3
 !F!raillerie 3
 
 !/!750:In keyboard config menu
 !=!Audio Taunt 4
 !G!Audio-Hohn 4
-!S!Provocación 4
+!S!Provocaciï¿½n 4
 !I!Provocazione audio 4
 !F!raillerie 4
 
 !/!751:Variable team game prompt
 !=!Please enter the number of teams for
-!G!Bitte Teamanzahl eingeben für
-!S!Introduce el número de equipos para
+!G!Bitte Teamanzahl eingeben fï¿½r
+!S!Introduce el nï¿½mero de equipos para
 !I!Immetti il numero di squadre per
 !F!entrez le nombre d'equipes pour
 
 !/!752:Dedicated server message if you try to set a variable that can't be set
 !=!This value can't be set during server initialization
-!G!Dieser Wert kann nicht während der Server-Initialisierung eingestellt werden
-!S!No se puede establecer este valor durante la inicialización del servidor
+!G!Dieser Wert kann nicht wï¿½hrend der Server-Initialisierung eingestellt werden
+!S!No se puede establecer este valor durante la inicializaciï¿½n del servidor
 !I!Impossibile impostare questo valore durante l'inizializzazione del server
-!F!Cette valeur ne peut être fixée lors de l'initialisation du serveur.
+!F!Cette valeur ne peut ï¿½tre fixï¿½e lors de l'initialisation du serveur.
 
 !/!753:Dedicated server message if you try to set a variable that can't be set
 !=!This value can't be set during game play
-!G!Dieser Wert kann nicht während des Spiels eingestellt werden
+!G!Dieser Wert kann nicht wï¿½hrend des Spiels eingestellt werden
 !S!No se puede establecer este valor durante el juego
 !I!Impossibile impostare questo valore durante il gioco
-!F!Cette valeur ne peut être fixée pendant le jeu.
+!F!Cette valeur ne peut ï¿½tre fixï¿½e pendant le jeu.
 
 !/!754:Message printed when there is an invalid number of teams set for a dedicated server
 !=!Invalid Number of Teams Set, defaulting to %d
-!G!Ungültige Teamanzahl eingestellt, es wird %d eingestellt
-!S!Número de equipos no válido. Adoptando valor predeterminado: %d
+!G!Ungï¿½ltige Teamanzahl eingestellt, es wird %d eingestellt
+!S!Nï¿½mero de equipos no vï¿½lido. Adoptando valor predeterminado: %d
 !I!Numero di squadre impostato non valido. Usato il valore predefinito di %d
-!F!Nombre d'Equipes Invalide. Passage à %d par défaut.
+!F!Nombre d'Equipes Invalide. Passage ï¿½ %d par dï¿½faut.
 
 !/!755:Descent 3: Retribution (The name of the main mission)
 !=!Descent 3: Retribution
 !G!Descent 3: Vergeltung
-!S!Descent 3: Retribución
+!S!Descent 3: Retribuciï¿½n
 !I!Descent 3: Ricompensa
-!F!Descent 3: Rétribution
+!F!Descent 3: Rï¿½tribution
 
 !/!756:Randomize powerup respawn
 !=!Randomize powerup respawn
 !G!Powerup Zufallsregenerierung
-!S!Aleatorizar aparición de bonificadores
+!S!Aleatorizar apariciï¿½n de bonificadores
 !I!Ricomparsa accelerata casuale
-!F!Apparition des recharges aléatoire
+!F!Apparition des recharges alï¿½atoire
 
 !/!757:Pilot dialog
 !=!CONTROLS CONFIGURATION
 !G!STEUERUNGSKONFIGURATION
-!S!CONFIGURACIÓN DE CONTROLES
+!S!CONFIGURACIï¿½N DE CONTROLES
 !I!CONFIGURAZIONE DEI COMANDI
 !F!CONFIGURER COMMANDES
 
@@ -5366,7 +5366,7 @@
 !=!MULTIPLAYER CONFIGURATION
 !G!MULTIPLAYERKONFIGURATION
 !S!CONFIG DEL MODO MULTIJUGADOR
-!I!CONFIGURAZIONE DELLA MODALITÀ MULTIGIOCATORE
+!I!CONFIGURAZIONE DELLA MODALITï¿½ MULTIGIOCATORE
 !F!CONFIGURER MODE MULTIJOUEUR
 
 !/!759:Misc. Pilot dialog section
@@ -5380,7 +5380,7 @@
 !=!FILTER PROFANITY
 !G!FLUCH-FILTER 
 !S!FILTRAR PROFANIDAD
-!I!FILTRA VOLGARITÀ
+!I!FILTRA VOLGARITï¿½
 !F!FILTRER VULGARITE
 
 !/!761:Pilot dialog error if there are no pilots to copy control config from
@@ -5388,27 +5388,27 @@
 !G!Kein Pilot vorhanden, von dem kopiert werden kann
 !S!No hay pilotos para copiar
 !I!Non esistono piloti da copiare
-!F!Vous devez disposer d'un autre pilote pour pouvoir copier les paramètres de configuration. 
+!F!Vous devez disposer d'un autre pilote pour pouvoir copier les paramï¿½tres de configuration. 
 
 !/!762:Fatal pilot file read error msg
 !=!An error has occurred reading your pilot file, please create a new one
 !G!Fehler beim Lesen der Pilotendatei, bitte erstellen Sie eine neue
 !S!Ha ocurrido un error al leer el archivo de piloto. Crea otro.
 !I!Errore durante la lettura del file del pilota. Creane un altro.
-!F!Erreur à la lecture de votre fichier pilote. Veuillez en créer un autre.
+!F!Erreur ï¿½ la lecture de votre fichier pilote. Veuillez en crï¿½er un autre.
 
 !/!763:Error if pilot file is so old it's unsupported
 !=!Your pilot file is too old, delete and create a new one
-!G!Pilotendatei ist zu alt, bitte löschen und neue erstellen
-!S!El archivo del piloto es demasiado antiguo. Bórralo y crea uno nuevo.
-!I!Il file del pilota è troppo vecchio. Eliminalo e creane un altro
-!F!Votre fichier pilote est trop vieux. Supprimez-le et créez-en un autre.
+!G!Pilotendatei ist zu alt, bitte lï¿½schen und neue erstellen
+!S!El archivo del piloto es demasiado antiguo. Bï¿½rralo y crea uno nuevo.
+!I!Il file del pilota ï¿½ troppo vecchio. Eliminalo e creane un altro
+!F!Votre fichier pilote est trop vieux. Supprimez-le et crï¿½ez-en un autre.
 
 !/!764:Error if pilot file is too new (we don't recognize it)
 !=!Pilot File '%s' is not compatible with this version. 
 !G!Pilotendatei '%s' ist mit dieser Version nicht kompatibel.
-!S!El archivo del piloto "%s" no es compatible con esta versión.
-!I!Il file del pilota "%s" non è compatibile con questa versione.
+!S!El archivo del piloto "%s" no es compatible con esta versiï¿½n.
+!I!Il file del pilota "%s" non ï¿½ compatibile con questa versione.
 !F!Le fichier pilote '%s' n'est pas compatible avec cette version.
 
 !/!765:TelCom Goal status if a goal/objective was failed
@@ -5421,28 +5421,28 @@
 !/!766:Score label for the HUD and the post-level results screen
 !=!Score
 !G!Punkte
-!S!Puntuación
+!S!Puntuaciï¿½n
 !I!Punteggio
 !F!Score
 
 !/!767:Post level results
 !=!Mission Successful
 !G!Mission erfolgreich
-!S!Misión cumplida
+!S!Misiï¿½n cumplida
 !I!Missione compiuta
 !F!Mission accomplie
 
 !/!768:Post level results
 !=!Mission Failed
 !G!Mission gescheitert
-!S!Misión fracasada
+!S!Misiï¿½n fracasada
 !I!Missione fallita
-!F!Mission Echouée
+!F!Mission Echouï¿½e
 
 !/!769:Label for the Guide-bot view window
 !=!Guide-Bot
 !G!Guide-Bot
-!S!Roboguía
+!S!Roboguï¿½a
 !I!Robot-Guida
 !F!Guidebot
 
@@ -5455,15 +5455,15 @@
 
 !/!771:Label for rear-view window
 !=!Rear
-!G!Rückansicht
+!G!Rï¿½ckansicht
 !S!Trasera
 !I!Posteriore
-!F!Arrière
+!F!Arriï¿½re
 
 !/!772:Prepare for Descent... (before the level starts)
 !=!Prepare for Descent...
-!G!Halten Sie sich bereit für Descent...
-!S!Prepárate para Descent...
+!G!Halten Sie sich bereit fï¿½r Descent...
+!S!Prepï¿½rate para Descent...
 !I!Preparati per Descent...
 !F!Tenez-vous pret !
 
@@ -5471,12 +5471,12 @@
 !=!You already have this weapon.
 !G!Sie haben diese Waffe schon.
 !S!Ya tienes esta arma.
-!I!Hai già quest'arma.
-!F!Vous avez déjà cette arme.
+!I!Hai giï¿½ quest'arma.
+!F!Vous avez dï¿½jï¿½ cette arme.
 
 !/!774:Press key to bind control (in controller config screen.)
 !=!Press key to bind control
-!G!Zum Zuweisen Taste drücken
+!G!Zum Zuweisen Taste drï¿½cken
 !S!Pulsa una tecla 
 !I!Premi un tasto 
 !F!Liez la commande
@@ -5484,30 +5484,30 @@
 !/!775:Press a button on your mouse (in controller config screen.)
 !=!Press a button on your mouse
 !G!Bitte eine Maustaste oder einen
-!S!Pulsa un botón del ratón
+!S!Pulsa un botï¿½n del ratï¿½n
 !I!Premi un pulsante del mouse
 !F!Pressez un bouton de votre souris
 
 !/!776:or joystick (including hat). (in controller config screen.)
 !=!or joystick (including hat).
-!G!Joystick-Knopf drücken.
-!S!o del joystick (hat incluído).
+!G!Joystick-Knopf drï¿½cken.
+!S!o del joystick (hat incluï¿½do).
 !I!o del joystick (hat compreso).
 !F!ou joystick (chapeau inclu).
 
 !/!777:Move your mouse or joystick (in controller config screen.)
 !=!Move your mouse or joystick
 !G!Bitte Maus oder Joystick in die
-!S!Mueve el ratón o el joystick
+!S!Mueve el ratï¿½n o el joystick
 !I!Sposta il mouse o il joystick
 !F!Bougez votre souris ou joystick
 
 !/!778:in the desired direction. (in controller config screen.)
 !=!in the desired direction.
-!G!gewünschte Richtung bewegen.
-!S!en la dirección deseada.
+!G!gewï¿½nschte Richtung bewegen.
+!S!en la direcciï¿½n deseada.
 !I!nella direzione desiderata.
-!F!dans la direction désirée.
+!F!dans la direction dï¿½sirï¿½e.
 
 !/!779:HUD Messages (HUD Message scrollback buffer dialog)
 !=!HUD Messages
@@ -5525,7 +5525,7 @@
 
 !/!781:Failed to open MN3 file. (Mission file error message)
 !=!Failed to open MN3 file.
-!G!MN3-Datei konnte nicht geöffnet werden.
+!G!MN3-Datei konnte nicht geï¿½ffnet werden.
 !S!No se puede abrir archivo MN3.
 !I!Impossibile aprire il file MN3.
 !F!Echec de l'ouverture du fichier MN3.
@@ -5533,34 +5533,34 @@
 !/!782:Command specified is a mission command. (Mission file error message)
 !=!Command specified is a mission command.
 !G!Eingegebenes Kommando ist ein Missionskommando.
-!S!Este comando pertenece a la misión.
+!S!Este comando pertenece a la misiï¿½n.
 !I!Il comando specificato appartiene alla missione.
-!F!La commande spécifiée est une commande de mission.
+!F!La commande spï¿½cifiï¿½e est une commande de mission.
 
 !/!783:Command specified is not a level command. (Mission file error message)
 !=!Command specified is not a level command.
 !G!Eingegebenes Kommando ist kein Levelkommando.
 !S!Este comando no pertenece al nivel.
 !I!Questo comando non appartiene al livello.
-!F!Le commande spécifiée n'est pas une commande de niveau.
+!F!Le commande spï¿½cifiï¿½e n'est pas une commande de niveau.
 
 !/!784:NUMLEVELS doesn't match number of level descript. (Mission file error message)
 !=!NUMLEVELS doesn't match number of level descript.
 !G!NUMLEVELS weicht von Levelnummer ab.
-!S!NUMLEVELS no encaja con el número de la descripción del nivel.
+!S!NUMLEVELS no encaja con el nï¿½mero de la descripciï¿½n del nivel.
 !I!NUMLEVELS non corrisponde al numero della descrizione del livello.
-!F!NUMLEVELS est différent du numéro de niveau.
+!F!NUMLEVELS est diffï¿½rent du numï¿½ro de niveau.
 
 !/!785:Level number is out of range. (Mission file error message)
 !=!Level number is out of range.
 !G!Levelnummer ausserhalb des Bereiches.
-!S!Nº de nivel fuera de intervalo.
+!S!Nï¿½ de nivel fuera de intervalo.
 !I!Numero di livello al di fuori dell'intervallo.
-!F!Numéro de niveau non disponible.
+!F!Numï¿½ro de niveau non disponible.
 
 !/!786:Illegal command %s (Mission file error message)
 !=!Illegal command %s
-!G!Ungültiges Kommando %s
+!G!Ungï¿½ltiges Kommando %s
 !S!Comando no admitido %s
 !I!Comando non consentito %s
 !F!Commande %s interdite
@@ -5570,18 +5570,18 @@
 !G!Missionsverzeichnis erstellen gescheitert
 !S!No se puede crear directorio de misiones
 !I!Impossibile creare la directory delle missioni
-!F!Création du répertoire des missions impossible
+!F!Crï¿½ation du rï¿½pertoire des missions impossible
 
 !/!788:Please insert Descent 3 CD %d (prompt for small install levels)
 !=!Please insert Descent 3 CD %d
 !G!Bitte Descent 3 CD %d einlegen
 !S!Inserta el CD %d de Descent 3
 !I!Inserisci il CD %d di Descent 3
-!F!Insérer le CD %d de Descent 3
+!F!Insï¿½rer le CD %d de Descent 3
 
 !/!789:Unable to configure joystick (error if calibrate joystick fails)
 !=!Unable to configure joystick.
-!G!Joystick-Konfiguration nicht möglich.
+!G!Joystick-Konfiguration nicht mï¿½glich.
 !S!No se puede configurar joystick.
 !I!Impossibile configurare il joystick.
 !F!Impossible de configurer le joystick.
@@ -5596,9 +5596,9 @@
 !/!791:Mouse Control (adjust settings for joystick and mouse)
 !=!Mouse Control
 !G!Maussteuerung
-!S!Control del ratón
+!S!Control del ratï¿½n
 !I!Controllo del mouse
-!F!Contrôle Souris
+!F!Contrï¿½le Souris
 
 !/!792:Flight Sim (adjust settings for mouse control)
 !=!Flight Sim
@@ -5610,28 +5610,35 @@
 !/!793:Mouselook (mouse control)
 !=!Mouselook
 !G!Mauslook
-!S!Vista con ratón
+!S!Vista con ratï¿½n
 !I!Vista con mouse
 !F!Vue avec la souris
+
+!/!1000:Inverted Flight Sim (adjust settings for mouse control)
+!=!Inverted Flight Sim
+!G!Umkehrflugsimulator
+!S!Simulador de vuelo invertido
+!I!Simulatore di volo invertito
+!F!Simulateur de vol inversÃ©e
 
 !/!794:Allow Mouselookers
 !=!Allow Mouselookers
 !G!Mauslook zulassen
-!S!Permitir vista con ratón
+!S!Permitir vista con ratï¿½n
 !I!Consenti viste con mouse
 !F!Autoriser la vue avec la souris
 
 !/!795:Mouselook not allowed (if a player tried to join a non-mouselook multiplayer game)
 !=!Mouselook not allowed
 !G!Mauslook nicht zugelassen
-!S!Vista con Ratón no permitida
+!S!Vista con Ratï¿½n no permitida
 !I!Vista con mouse non consentita
 !F!Vue avec la souris interdite
 
 !/!796:if a player tried to join a non-mouselook multiplayer game
 !=!This game does not allow mouselook. Do you want to join anyway?
-!G!Das Spiel lässt keinen Mauslook zu. Möchten Sie trotzdem teilnehmen?
-!S!Esta partida no acepta vista con ratón. ¿Quieres unirte de todas formas?
+!G!Das Spiel lï¿½sst keinen Mauslook zu. Mï¿½chten Sie trotzdem teilnehmen?
+!S!Esta partida no acepta vista con ratï¿½n. ï¿½Quieres unirte de todas formas?
 !I!Questa partita non consente la vista con mouse. Partecipi comunque?
 !F!Cette partie n'autorise pas la vue avec la souris. Voulez-vous continuer ?
 
@@ -5640,12 +5647,12 @@
 !G!Training abbrechen
 !S!Detener entrenamiento
 !I!Interrompi l'addestramento
-!F!arreter l'entraînement
+!F!arreter l'entraï¿½nement
 
 !/!798:if you try to exit the training mission the first time you play it
 !=!Do you want to Skip to the first level, or abort the Mission?
-!G!Möchten Sie zum ersten Level springen, oder die Mission abbrechen?
-!S!¿Quieres saltar al primer nivel o detener la misión?
+!G!Mï¿½chten Sie zum ersten Level springen, oder die Mission abbrechen?
+!S!ï¿½Quieres saltar al primer nivel o detener la misiï¿½n?
 !I!Passare al primo livello o interrompere la missione?
 !F!Voulez-vous passer directement au premier niveau, ou annuler la mission ?
 
@@ -5675,12 +5682,12 @@
 !G!Spiel gespeichert.
 !S!Partida guardada.
 !I!Partita salvata.
-!F!Partie sauvegardée.
+!F!Partie sauvegardï¿½e.
 
 !/!803:Hit a button or the spacebar to continue (Post level results screen)
 !=!Hit a button or the spacebar to continue
 !G!Weiter mit 'Leertaste'.
-!S!Pulsa un botón o la barra espaciadora para continuar.
+!S!Pulsa un botï¿½n o la barra espaciadora para continuar.
 !I!Premi un tasto o la barra spazio per continuare
 !F!Appuyez sur la barre d'espace pour continuer.
 
@@ -5700,17 +5707,17 @@
 
 !/!806:Friendlies destroyed, on post-level results screen
 !=!Friendlies destroyed:
-!G!Zerstörte Verbündete:
-!S!Compañeros destruidos:
+!G!Zerstï¿½rte Verbï¿½ndete:
+!S!Compaï¿½eros destruidos:
 !I!Alleati distrutti:
-!F!alliés détruits:
+!F!alliï¿½s dï¿½truits:
 
 !/!807:This mission is not compatible with the selected multiplayer mode. (error for multiplayer)
 !=!This mission is not compatible with the selected multiplayer mode.
-!G!Diese Mission ist mit dem gewählten Multiplayer-Modus nicht kompatibel.
-!S!Esta misión no es compatible con el modo multijugador seleccionado.
-!I!Questa missione non è compatibile con la modalità multigiocatore.
-!F!Cette mission n'est pas compatible avec le mode multijoueur sélectionné.
+!G!Diese Mission ist mit dem gewï¿½hlten Multiplayer-Modus nicht kompatibel.
+!S!Esta misiï¿½n no es compatible con el modo multijugador seleccionado.
+!I!Questa missione non ï¿½ compatibile con la modalitï¿½ multigiocatore.
+!F!Cette mission n'est pas compatible avec le mode multijoueur sï¿½lectionnï¿½.
 
 !/!808:Used in Pilot ship customization dialog
 !=!Multiplayer Ship Configuration
@@ -5721,31 +5728,31 @@
 
 !/!809: HUD Name for Afterburner Cooler
 !=!AB Cooler
-!G!NB-Kühler
+!G!NB-Kï¿½hler
 !S!PC Refrig
 !I!Raffreddamento PC
 !F!refroidissant PC
 
 !/!810: HUD Message when you get back your stolen automap
 !=!Your automap has been retrieved
-!G!Sie haben Ihre Autom. Karte zurückbekommen
+!G!Sie haben Ihre Autom. Karte zurï¿½ckbekommen
 !S!El automapa ha sido recuperado
 !I!Auto-mappa recuperata
-!F!votre autocarte a été récupérée.
+!F!votre autocarte a ï¿½tï¿½ rï¿½cupï¿½rï¿½e.
 
 !/!811: HUD Message when you get back your stolen headlight
 !=!Your headlight has been retrieved
-!G!Sie haben Ihre Scheinwerfer zurückbekommen
+!G!Sie haben Ihre Scheinwerfer zurï¿½ckbekommen
 !S!Los faros delanteros han sido recuperados
 !I!Fanale recuperato
-!F!votre phare a été récupéré.
+!F!votre phare a ï¿½tï¿½ rï¿½cupï¿½rï¿½.
 
 !/!812: HUD Message when you try to pickup a headlight you already have
 !=!You already have a headlight
 !G!Sie haben schon Scheinwerfer
 !S!Ya tienes los faros delanteros
-!I!Hai già un fanale
-!F!vous avez déjà un phare.
+!I!Hai giï¿½ un fanale
+!F!vous avez dï¿½jï¿½ un phare.
 
 !/!813: HDU Message if you try to turn on your headlight but don't have it
 !=!You don't have any headlight
@@ -5759,14 +5766,14 @@
 !G!Fernlenk-Ansicht
 !S!Vista de misil guiado
 !I!Vista dal missile teleguidato
-!F!vue du missile guidé
+!F!vue du missile guidï¿½
 
 !/!815: In General Options Menu to toggle on/off gun reticle
 !=!Show reticle
 !G!Fadenkreuz
 !S!Muestra diana
 !I!Mostra reticolo
-!F!réticule
+!F!rï¿½ticule
 
 !/!816: In General Options Menu to toggle on/off ship engine sounds
 !=!Ship sounds
@@ -5779,7 +5786,7 @@
 !=!SFX Quantity
 !G!Effekt Anzahl
 !S!Calidad efectos
-!I!Quantità effetti sonori
+!I!Quantitï¿½ effetti sonori
 !F!effets sonores
 
 !/!818:Dedicated server: %s (game-info screen if you hit 'i' while a game is selected in multiplayer)
@@ -5787,19 +5794,19 @@
 !G!Dedizierter Server: %s
 !S!Servidor dedicado: %s
 !I!Server dedicato: %s 
-!F!serveur dédié: %s
+!F!serveur dï¿½diï¿½: %s
 
 !/!819:Nondedicated server: %s (game-info screen if you hit 'i' while a game is selected in multiplayer)
 !=!Nondedicated server: %s
 !G!Nicht-dedizierter Server: %s
 !S!Servidor no dedicado: %s
 !I!Server non dedicato: %s 
-!F!serveur non dédié: %s
+!F!serveur non dï¿½diï¿½: %s
 
 !/!820:%s allow Mouselook. (game-info screen if you hit 'i' while a game is selected in multiplayer)
 !=!%s allow Mouselook.
 !G!Mouselook zulassen: %s
-!S!%s permite vista de ratón
+!S!%s permite vista de ratï¿½n
 !I!vista con mouse %s
 !F!vue avec la souris %s.
 
@@ -5808,7 +5815,7 @@
 !G!Ja
 !S!Si
 !I!consentita
-!F!autorisée
+!F!autorisï¿½e
 
 !/!822:Does not (game-info screen if you hit 'i' while a game is selected in multiplayer)
 !=!Does not
@@ -5822,21 +5829,21 @@
 !G!Genaue Waffenkollisionen: %s
 !S!Colisiones reales de armas: %s
 !I!Collisioni precise tra armi: %s
-!F!collisions d'armes précises: %s
+!F!collisions d'armes prï¿½cises: %s
 
 !/!824:Use rotational velocity: %s (game-info screen if you hit 'i' while a game is selected in multiplayer)
 !=!Use rotational velocity: %s
 !G!Drehgeschw. verwenden: %s
 !S!Utiliza velocidad rotacional: %s
-!I!Usa velocità di rotazione: %s
+!I!Usa velocitï¿½ di rotazione: %s
 !F!utiliser vitesse de rotation: %s
 
 !/!825:Randomize powerup respawn: %s (game-info screen if you hit 'i' while a game is selected in multiplayer)
 !=!Randomize powerup respawn: %s
-!G!Zufällige Powerup-Wiederherst.: %s 
-!S!Creación aleatoria de bonificadores: %s
+!G!Zufï¿½llige Powerup-Wiederherst.: %s 
+!S!Creaciï¿½n aleatoria de bonificadores: %s
 !I!Comparsa casuale dei bonus: %s
-!F!apparition des recharges aléatoire: %s
+!F!apparition des recharges alï¿½atoire: %s
 
 !/!826:Players: %d of %d (game-info screen if you hit 'i' while a game is selected in multiplayer)
 !=!Players: %d of %d
@@ -5848,7 +5855,7 @@
 !/!827:Mission: %s (game-info screen if you hit 'i' while a game is selected in multiplayer)
 !=!Mission: %s
 !G!Mission: %s
-!S!Misión: %s
+!S!Misiï¿½n: %s
 !I!Missione: %s 
 !F!mission: %s
 
@@ -5861,10 +5868,10 @@
 
 !/!829:Error message if your pilot file's version is too new to read
 !=!The selected pilot (%s) is too new, please delete and create a new one
-!G!Der gewählte Pilot (%s) ist zu neu, bitte löschen und einen neuen erstellen
+!G!Der gewï¿½hlte Pilot (%s) ist zu neu, bitte lï¿½schen und einen neuen erstellen
 !S!El piloto seleccionado (%s) es muy nuevo, borralo y crea uno nuevo.
-!I!Il pilota selezionato (%s) è troppo recente. Eliminarlo e crearne un altro.
-!F!le pilote sélectionné (%s) est trop récent. Supprimez-le et créez en un autre.
+!I!Il pilota selezionato (%s) ï¿½ troppo recente. Eliminarlo e crearne un altro.
+!F!le pilote sï¿½lectionnï¿½ (%s) est trop rï¿½cent. Supprimez-le et crï¿½ez en un autre.
 
 !/!830:Wait message displayed when going into TelCom
 !=!Accessing TelCom...Please wait
@@ -5876,7 +5883,7 @@
 !/!831:Couldn't get player list from server! (Game info error message)
 !=!Couldn't get player list from server!
 !G!Spielerliste konnte nicht vom Server erhalten werden!
-!S!¡No obtuve lista de jugadores sel servidor!
+!S!ï¿½No obtuve lista de jugadores sel servidor!
 !I!Impossibile ottenere elenco giocatori dal server
 !F!le serveur n'a pu fournir la liste de joueurs !
 
@@ -5897,16 +5904,16 @@
 !/!834:You have found a secret area (printed when player first enters a secret area)
 !=!You have found a secret area!
 !G!Sie haben einen geheimen Bereich gefunden!
-!S!Abéis encontrado un area secreta
+!S!Abï¿½is encontrado un area secreta
 !I!Hai trovato una zona segreta
-!F!vous avez découvert une zone secrète !
+!F!vous avez dï¿½couvert une zone secrï¿½te !
 
 !/!835:Game restored. (put on HUD when you load a savegame)
 !=!Game restored.
 !G!Spiel geladen.
 !S!Partida recuperada.
 !I!Partita ripristinata.
-!F!partie restaurée.
+!F!partie restaurï¿½e.
 
 !/!836: in pilot menu, option for audio taunts
 !=!Audio Taunts
@@ -5918,14 +5925,14 @@
 !/!837: in guidebot menu (for clients in multiplayer games)
 !=!Guidebot
 !G!Guide-Bot
-!S!Roboguía
+!S!Roboguï¿½a
 !I!Robot-Guida
 !F!guidebot
 
 !/!838: in guidebot menu (for clients in multiplayer games)
 !=!Please wait, accessing Guidebot
 !G!Bitte warten, kontakte Guide-Bot
-!S!Espere, accesando al Roboguía
+!S!Espere, accesando al Roboguï¿½a
 !I!Attendere, connessione a Robot-Guida
 !F!connexion au guidebot... Veuillez patienter.
 
@@ -5939,62 +5946,62 @@
 !/!840: Exit message when quitting from main menu
 !=!Are you sure you want to exit?
 !G!Wollen Sie wirklich beenden?
-!S!¿Estas seguro que quieres salir?
+!S!ï¿½Estas seguro que quieres salir?
 !I!Sicuro di voler uscire?
-!F!etes-vous sûr de vouloir quitter ?
+!F!etes-vous sï¿½r de vouloir quitter ?
 
 !/!841: generic help for the controller config screens to clear a key/joy binding
 !=!Use CTRL-C to clear currently highlighted slot.
 !G!Mit STRG-C die derzeitig markierte Zeile bereinigen.
-!S!Usa CTRL-C para borrar la selección iluminada.
+!S!Usa CTRL-C para borrar la selecciï¿½n iluminada.
 !I!Usa CTRL-C per cancellare lo slot selezionato.
-!F!CTRL+C vous permet d'effacer la sélection actuelle.
+!F!CTRL+C vous permet d'effacer la sï¿½lection actuelle.
 
 !/!842: help for keyboard config screen
 !=!Press '?' for help.
 !G!Mit '?' zur Hilfe.
 !S!Pulsa '?' para ayuda.
 !I!Premere '?' per richiamare la Guida.
-!F!cliquez sur '?' pour appeler l'écran d'aide.
+!F!cliquez sur '?' pour appeler l'ï¿½cran d'aide.
 
 !/!843: help for joystick config screen
 !=!Press '?' for help, or to invert axis.
 !G!Mit '?' zur Hilfe, oder Achse umkehren.
 !S!Pulsa '?' para ayuda o para invertir el eje.
 !I!Premere '?' per richiamare la Guida o per invertire l'asse.
-!F!'?': voir l'écran d'aide ou inverser l'axe.
+!F!'?': voir l'ï¿½cran d'aide ou inverser l'axe.
 
 !/!844: Title for keyboard ramping slider in joystick adjust settings
 !=!Key Ramping Time (s)
 !G!Erwiderung (s)
-!S!Tiempo de repetición de teclado
+!S!Tiempo de repeticiï¿½n de teclado
 !I!Tempo di ripetizione (s)
-!F!temps de répétition (s)
+!F!temps de rï¿½pï¿½tition (s)
 
 !/!845: title of controller settings in general options menu
 !=!Controller settings
 !G!Steuerungseinstellung
-!S!Configuración de control
-!I!Impostazioni dell'unità di controllo
+!S!Configuraciï¿½n de control
+!I!Impostazioni dell'unitï¿½ di controllo
 !F!config. du controleur
 
 !/!846: shortcut to joystick adjust settings located in general options
 !=!Sensitivity
 !G!Empfindlichkeit
 !S!Sensibilidad
-!I!Sensibilità
+!I!Sensibilitï¿½
 !F!sensibilite
 
 !/!847: shortcut to keyboard adjust settings located in general options
 !=!Keyboard Ramping
 !G!Tastenerwiderung
-!S!Repetición de teclado
+!S!Repeticiï¿½n de teclado
 !I!Ripetizione da tastiera
 !F!repetition du clavier
 
 !/!848: used in help for weapon autoselect config after pressing button
 !=!Click slot to put weapon into.
-!G!Waffe durch Klicken einfügen.
+!G!Waffe durch Klicken einfï¿½gen.
 !S!Haz clic para colocar arma.
 !I!Fare clic sullo slot in cui inserire l'arma.
 !F!cliquez sur l'emplacement de l'arme.
@@ -6015,155 +6022,155 @@
 !/!Pyro-GL (850-857)
 !=!\1\255\255\255Max. Trans-Atmospheric Speed:\1\160\153\222 2,000 Knots
 !G!\1\255\255\255Max. Trans-Atmospherengeschw.:\1\160\153\222 2,000 Knoten
-!S!\1\255\255\255Límite de velocidad transatmosférica:\1\160\153\222 2,000 nudos 
-!I!\1\255\255\255Velocità transatmosferica max:\1\160\153\222 2.000 nodi
-!F!\1\255\255\255Vitesse transatmosphérique max:\1\160\153\222 2,000 noeuds 
+!S!\1\255\255\255Lï¿½mite de velocidad transatmosfï¿½rica:\1\160\153\222 2,000 nudos 
+!I!\1\255\255\255Velocitï¿½ transatmosferica max:\1\160\153\222 2.000 nodi
+!F!\1\255\255\255Vitesse transatmosphï¿½rique max:\1\160\153\222 2,000 noeuds 
 
 !=!\1\255\255\255Maneuverability Rating:\1\160\153\222 4.62 ZG-Units
-!G!\1\255\255\255Manövrierleistung:\1\160\153\222 4.62 ZG-Einheiten 
+!G!\1\255\255\255Manï¿½vrierleistung:\1\160\153\222 4.62 ZG-Einheiten 
 !S!\1\255\255\255Maniobrabilidad:\1\160\153\222 4.62 ZG-Unidades 
-!I!\1\255\255\255Manovrabilità:\1\160\153\222 4,62 Unità ZG 
-!F!\1\255\255\255Taux de manoeuvrabilité:\1\160\153\222 4.62 unités ZG
+!I!\1\255\255\255Manovrabilitï¿½:\1\160\153\222 4,62 Unitï¿½ ZG 
+!F!\1\255\255\255Taux de manoeuvrabilitï¿½:\1\160\153\222 4.62 unitï¿½s ZG
 
 
 !=!\1\255\255\255Shield Rating:\1\160\153\222 1.0 Flux :Standard output, ACM grade Magneto-Repulsory Wave Device
-!G!\1\255\255\255Schildleistung:\1\160\153\222 1.0 Flux :Standard Output, ACM-Klasse Magnetrückstosswellengerät
-!S!\1\255\255\255Grado de escudo:\1\160\153\222 1.0 Flux:Producción media, dispositivo de onda magneto-repulsora de grado ACM 
+!G!\1\255\255\255Schildleistung:\1\160\153\222 1.0 Flux :Standard Output, ACM-Klasse Magnetrï¿½ckstosswellengerï¿½t
+!S!\1\255\255\255Grado de escudo:\1\160\153\222 1.0 Flux:Producciï¿½n media, dispositivo de onda magneto-repulsora de grado ACM 
 !I!\1\255\255\255Grado di protezione:\1\160\153\222 1,0 Flux :Output standard, dispositivo ad onde magneto-repulsive di grado ACM
 !F!\1\255\255\255Taux Bouclier:\1\160\153\222 1.0 Flux: sortie standard, dispositif VMR, grade ACM
 
 !=!\1\255\255\255Ordnance:\1\160\153\222 Mid-Level Primary fuselage configuration, with a maximum secondary payload of 100 missile stores in in
-!G!\1\255\255\255Geschütz:\1\160\153\222 Rumpfkonfiguriertes Primär der mittleren Stufe mit einer maximalen Sekundärzuladung von 100 Geschossen
-!S!\1\255\255\255Artillería:\1\160\153\222 Configuración de fuselaje primario de medio nivel, con una capacidad máxima de armas secundarias de 100 misiles
+!G!\1\255\255\255Geschï¿½tz:\1\160\153\222 Rumpfkonfiguriertes Primï¿½r der mittleren Stufe mit einer maximalen Sekundï¿½rzuladung von 100 Geschossen
+!S!\1\255\255\255Artillerï¿½a:\1\160\153\222 Configuraciï¿½n de fuselaje primario de medio nivel, con una capacidad mï¿½xima de armas secundarias de 100 misiles
 
 !I!\1\255\255\255Artiglieria:\1\160\153\222 Configurazione della fusoliera primaria di medio livello, con una capienza massima di armi secondarie pari a 100 missili
-!F!\1\255\255\255Artillerie:\1\160\153\222 Configuration du fuselage primaire à mi-niveau, avec un max d'armes secondaires de 100 missiles 
+!F!\1\255\255\255Artillerie:\1\160\153\222 Configuration du fuselage primaire ï¿½ mi-niveau, avec un max d'armes secondaires de 100 missiles 
 
 !=!\1\255\255\255Wing Span:\1\160\153\222 13.5 Units
 !G!\1\255\255\255Spannweite:\1\160\153\222 13.5 Einheiten
 !S!\1\255\255\255Largo de alas:\1\160\153\222 13.5 Unidades 
-!I!\1\255\255\255Apertura alare:\1\160\153\222 13,5 Unità 
-!F!\1\255\255\255Enverg. aile:\1\160\153\222 13.5 Unités
+!I!\1\255\255\255Apertura alare:\1\160\153\222 13,5 Unitï¿½ 
+!F!\1\255\255\255Enverg. aile:\1\160\153\222 13.5 Unitï¿½s
 
 !=!\1\255\255\255Overall Length:\1\160\153\222 14.55 Units
-!G!\1\255\255\255Gesamtlänge:\1\160\153\222 14.55 Einheiten
+!G!\1\255\255\255Gesamtlï¿½nge:\1\160\153\222 14.55 Einheiten
 !S!\1\255\255\255Largo total:\1\160\153\222 14.55 Unidades 
-!I!!=!\1\255\255\255Lunghezza totale:\1\160\153\222 14,55 Unità 
-!F!\1\255\255\255Longueur:\1\160\153\222 14.55 Unités
+!I!!=!\1\255\255\255Lunghezza totale:\1\160\153\222 14,55 Unitï¿½ 
+!F!\1\255\255\255Longueur:\1\160\153\222 14.55 Unitï¿½s
 
 !=!\1\255\255\255Height: \1\160\153\222 7.35 Units
-!G!\1\255\255\255Höhe: \1\160\153\222 7.35 Einheiten
+!G!\1\255\255\255Hï¿½he: \1\160\153\222 7.35 Einheiten
 !S!\1\255\255\255Altura: \1\160\153\222 7.35 Unidades
-!I!\1\255\255\255Altezza: \1\160\153\222 7,35 Unità 
-!F!\1\255\255\255Hauteur: \1\160\153\222 7.35 Unités
+!I!\1\255\255\255Altezza: \1\160\153\222 7,35 Unitï¿½ 
+!F!\1\255\255\255Hauteur: \1\160\153\222 7.35 Unitï¿½s
 
 
 !=!\1\255\255\255Weight Empty: \1\160\153\222 12,833 Lbs
 !G!\1\255\255\255Leergewicht: \1\160\153\222 6.416 kg
-!S!\1\255\255\255Peso vacío: \1\160\153\222 6.416 kg 
+!S!\1\255\255\255Peso vacï¿½o: \1\160\153\222 6.416 kg 
 !I!\1\255\255\255Peso a vuoto: \1\160\153\222 6.416 kg 
-!F!\1\255\255\255Poids à vide: \1\160\153\222 6.416 kg 
+!F!\1\255\255\255Poids ï¿½ vide: \1\160\153\222 6.416 kg 
 
 
 !/!Phoenix (858-865)
 !=!\1\255\255\255Max. Trans-Atmospheric Speed:\1\160\153\222 2,790 Knots
 !G!\1\255\255\255Max. Trans-Atmospheengeschw.:\1\160\153\222 2,790 Knoten
-!S!\1\255\255\255Límite de velocidad transatmosférica:\1\160\153\222 2,790 nudos 
-!I!\1\255\255\255Velocità transatmosferica max:\1\160\153\222 2.790 nodi
-!F!\1\255\255\255Vitesse transatmosphérique max.:\1\160\153\222 2,790 noeuds
+!S!\1\255\255\255Lï¿½mite de velocidad transatmosfï¿½rica:\1\160\153\222 2,790 nudos 
+!I!\1\255\255\255Velocitï¿½ transatmosferica max:\1\160\153\222 2.790 nodi
+!F!\1\255\255\255Vitesse transatmosphï¿½rique max.:\1\160\153\222 2,790 noeuds
 
 
 !=!\1\255\255\255Maneuverability Rating:\1\160\153\222 8.0 ZG-Units
-!G!\1\255\255\255Manövrierleistung:\1\160\153\222 8.0 ZG-Einheiten
+!G!\1\255\255\255Manï¿½vrierleistung:\1\160\153\222 8.0 ZG-Einheiten
 !S!\1\255\255\255Maniobrabilidad:\1\160\153\222 8.0 ZG-Unidades 
-!I!\1\255\255\255Manovrabilità:\1\160\153\222 8,0 Unità ZG 
-!F!\1\255\255\255Taux de manoeuvrabilité:\1\160\153\222 8.0 unités ZG
+!I!\1\255\255\255Manovrabilitï¿½:\1\160\153\222 8,0 Unitï¿½ ZG 
+!F!\1\255\255\255Taux de manoeuvrabilitï¿½:\1\160\153\222 8.0 unitï¿½s ZG
 
 
 !=!\1\255\255\255Shield Rating:\1\160\153\222 0.85 Flux :Minimal output, CCM grade Magneto-Repulsory Wave Device
-!G!\1\255\255\255Schildleistung:\1\160\153\222 0.85 Flux :Minimal Output, CCM-Klasse Magnetrückstosswellengerät
-!S!\1\255\255\255Grado de escudo:\1\160\153\222 0.85 Flux:Producción minima, dispositivo de onda magneto-repulsora de grado CCM 
+!G!\1\255\255\255Schildleistung:\1\160\153\222 0.85 Flux :Minimal Output, CCM-Klasse Magnetrï¿½ckstosswellengerï¿½t
+!S!\1\255\255\255Grado de escudo:\1\160\153\222 0.85 Flux:Producciï¿½n minima, dispositivo de onda magneto-repulsora de grado CCM 
 !I!\1\255\255\255Grado di protezione:\1\160\153\222 0,85 Flux :Output minimo, dispositivo ad onde magneto-repulsive di grado CCM
 !F!\1\255\255\255Taux Bouclier:\1\160\153\222 0.85 Flux: sortie minimale, dispositif VMR, grade ACM 
 
 !=!\1\255\255\255Ordnance:\1\160\153\222 Low-Level Primary fuselage configuration, with a maximum secondary payload of 66 missile stores in int
-!G!\1\255\255\255Geschütz:\1\160\153\222 Rumpfkonfiguriertes Primär der unteren Stufe mit einer maximalen Sekundärzuladung von 66 Geschossen
-!S!\1\255\255\255Artillería:\1\160\153\222 Configuración de fuselaje primario de bajo nivel, con una capacidad máxima de armas secundarias de 66 misiles
+!G!\1\255\255\255Geschï¿½tz:\1\160\153\222 Rumpfkonfiguriertes Primï¿½r der unteren Stufe mit einer maximalen Sekundï¿½rzuladung von 66 Geschossen
+!S!\1\255\255\255Artillerï¿½a:\1\160\153\222 Configuraciï¿½n de fuselaje primario de bajo nivel, con una capacidad mï¿½xima de armas secundarias de 66 misiles
 !I!\1\255\255\255Artiglieria:\1\160\153\222 Configurazione della fusoliera primaria di basso livello, con una capienza massima di armi secondarie pari a 66 missili
-!F!\1\255\255\255Artillerie:\1\160\153\222 Configuration du fuselage primaire à niveau bas, avec un max d'armes secondaires de 66 missiles 
+!F!\1\255\255\255Artillerie:\1\160\153\222 Configuration du fuselage primaire ï¿½ niveau bas, avec un max d'armes secondaires de 66 missiles 
 
 !=!\1\255\255\255Wing Span:\1\160\153\222 13.7 Units
 !G!\1\255\255\255Spannweite:\1\160\153\222 13.7 Einheiten
 !S!\1\255\255\255Largo de alas:\1\160\153\222 13.7 Unidades 
-!I!\1\255\255\255Apertura alare:\1\160\153\222 13,7 Unità
-!F!\1\255\255\255Enverg. aile:\1\160\153\222 13.7 Unités
+!I!\1\255\255\255Apertura alare:\1\160\153\222 13,7 Unitï¿½
+!F!\1\255\255\255Enverg. aile:\1\160\153\222 13.7 Unitï¿½s
 
 !=!\1\255\255\255Overall Length:\1\160\153\222 17.25 Units
-!G!\1\255\255\255Gesamtlänge:\1\160\153\222 17.25 Einheiten
+!G!\1\255\255\255Gesamtlï¿½nge:\1\160\153\222 17.25 Einheiten
 !S!\1\255\255\255Largo total:\1\160\153\222 17.25 Unidades 
-!I!\1\255\255\255Lunghezza totale:\1\160\153\222 17,25 Unità 
-!F!\1\255\255\255Longueur:\1\160\153\222 17.25 Unités
+!I!\1\255\255\255Lunghezza totale:\1\160\153\222 17,25 Unitï¿½ 
+!F!\1\255\255\255Longueur:\1\160\153\222 17.25 Unitï¿½s
 
 !=!\1\255\255\255Height: \1\160\153\222 5.1 Units
-!G!\1\255\255\255Höhe: \1\160\153\222 5.1 Einheiten
+!G!\1\255\255\255Hï¿½he: \1\160\153\222 5.1 Einheiten
 !S!\1\255\255\255Altura: \1\160\153\222 5.1 Unidades 
-!I!\1\255\255\255Altezza: \1\160\153\222 5,1 Unità 
-!F!\1\255\255\255Hauteur: \1\160\153\222 5.1 Unités
+!I!\1\255\255\255Altezza: \1\160\153\222 5,1 Unitï¿½ 
+!F!\1\255\255\255Hauteur: \1\160\153\222 5.1 Unitï¿½s
 
 !=!\1\255\255\255Weight Empty: \1\160\153\222 10,445 Lbs
 !G!\1\255\255\255Leergewicht: \1\160\153\222 5.222 kg
-!S!\1\255\255\255Peso vacío: \1\160\153\222 5.222 kg 
+!S!\1\255\255\255Peso vacï¿½o: \1\160\153\222 5.222 kg 
 !I!\1\255\255\255Peso a vuoto: \1\160\153\222 5.222 kg 
-!F!\1\255\255\255Poids à vide: \1\160\153\222 5.222 kg
+!F!\1\255\255\255Poids ï¿½ vide: \1\160\153\222 5.222 kg
 
 !/!Magnum (866-873)
 !=!\1\255\255\255Max. Trans-Atmospheric Speed:\1\160\153\222 1,530 Knots
 !G!\1\255\255\255Max. Trans-Atmospheengeschw.:\1\160\153\222 1,530 Knoten
-!S!\1\255\255\255Límite de velocidad transatmosférica:\1\160\153\222 1,530 nudos 
-!I!\1\255\255\255Velocità transatmosferica max:\1\160\153\222 1.530 nodi 
-!F!\1\255\255\255Vitesse transatmosphérique max:\1\160\153\222 1,530 noeuds
+!S!\1\255\255\255Lï¿½mite de velocidad transatmosfï¿½rica:\1\160\153\222 1,530 nudos 
+!I!\1\255\255\255Velocitï¿½ transatmosferica max:\1\160\153\222 1.530 nodi 
+!F!\1\255\255\255Vitesse transatmosphï¿½rique max:\1\160\153\222 1,530 noeuds
 
 !=!\1\255\255\255Maneuverability Rating:\1\160\153\222 3.2 ZG-Units
-!G!\1\255\255\255Manövrierleistung:\1\160\153\222 3.2 ZG-Einheiten
+!G!\1\255\255\255Manï¿½vrierleistung:\1\160\153\222 3.2 ZG-Einheiten
 !S!\1\255\255\255Maniobrabilidad:\1\160\153\222 3.2 ZG-Unidades 
-!I!\1\255\255\255Manovrabilità:\1\160\153\222 3,2 Unità ZG 
-!F!\1\255\255\255Taux de manoeuvrabilité:\1\160\153\222 3.2 unités ZG
+!I!\1\255\255\255Manovrabilitï¿½:\1\160\153\222 3,2 Unitï¿½ ZG 
+!F!\1\255\255\255Taux de manoeuvrabilitï¿½:\1\160\153\222 3.2 unitï¿½s ZG
 
 !=!\1\255\255\255Shield Rating:\1\160\153\222 1.13 Flux :Enhanced output, DCM grade Magneto-Repulsory Wave Device
-!G!\1\255\255\255Schildleistung:\1\160\153\222 1.13 Flux :Verstärkter Output, DCM-Klasse Magnetrückstosswellengerät
-!S!\1\255\255\255Grado de escudo:\1\160\153\222 1.13 Flux:Producción optima, dispositivo de onda magneto-repulsora de grado DCM 
+!G!\1\255\255\255Schildleistung:\1\160\153\222 1.13 Flux :Verstï¿½rkter Output, DCM-Klasse Magnetrï¿½ckstosswellengerï¿½t
+!S!\1\255\255\255Grado de escudo:\1\160\153\222 1.13 Flux:Producciï¿½n optima, dispositivo de onda magneto-repulsora de grado DCM 
 !I!\1\255\255\255Grado di protezione:\1\160\153\222 1,13 Flux :Output massimo, dispositivo ad onde magneto-repulsive di grado DCM 
-!F!\1\255\255\255Taux Bouclier:\1\160\153\222 1.13 Flux: sortie optimisée, dispositif VMR, grade ACM
+!F!\1\255\255\255Taux Bouclier:\1\160\153\222 1.13 Flux: sortie optimisï¿½e, dispositif VMR, grade ACM
 
 !=!\1\255\255\255Ordnance:\1\160\153\222 High-Level Primary fuselage configuration, with a maximum secondary payload of 143 missile stores in i
-!G!\1\255\255\255Geschütz:\1\160\153\222 Rumpfkonfiguriertes Primär der oberen Stufe mit einer maximalen Sekundärzuladung von 143 Geschossen
-!S!\1\255\255\255Artillería:\1\160\153\222 Configuración de fuselaje primario de alto nivel, con una capacidad máxima de armas secundarias de 143 misiles
+!G!\1\255\255\255Geschï¿½tz:\1\160\153\222 Rumpfkonfiguriertes Primï¿½r der oberen Stufe mit einer maximalen Sekundï¿½rzuladung von 143 Geschossen
+!S!\1\255\255\255Artillerï¿½a:\1\160\153\222 Configuraciï¿½n de fuselaje primario de alto nivel, con una capacidad mï¿½xima de armas secundarias de 143 misiles
 !I!\1\255\255\255Artiglieria:\1\160\153\222 Configurazione della fusoliera primaria di alto livello, con una capienza massima di armi secondarie pari a 143 missili
-!F!\1\255\255\255Artillerie:\1\160\153\222 Configuration du fuselage primaire à haut niveau, avec un max d'armes secondaires de 143 missiles
+!F!\1\255\255\255Artillerie:\1\160\153\222 Configuration du fuselage primaire ï¿½ haut niveau, avec un max d'armes secondaires de 143 missiles
 
 !=!\1\255\255\255Wing Span:\1\160\153\222 13.65 Units
 !G!\1\255\255\255Spannweite:\1\160\153\222 13.65 Einheiten
 !S!\1\255\255\255Largo de alas:\1\160\153\222 13.65 Unidades 
-!I!\1\255\255\255Apertura alare:\1\160\153\222 13,65 Unità 
-!F!\1\255\255\255Enverg. aile:\1\160\153\222 13.65 Unités
+!I!\1\255\255\255Apertura alare:\1\160\153\222 13,65 Unitï¿½ 
+!F!\1\255\255\255Enverg. aile:\1\160\153\222 13.65 Unitï¿½s
 
 !=!\1\255\255\255Overall Length:\1\160\153\222 17.7 Units
-!G!\1\255\255\255Gesamtlänge:\1\160\153\222 17.7 Einheiten
+!G!\1\255\255\255Gesamtlï¿½nge:\1\160\153\222 17.7 Einheiten
 !S!\1\255\255\255Largo total:\1\160\153\222 17.7 Unidades
-!I!\1\255\255\255Lunghezza totale:\1\160\153\222 17,7 Unità
-!F!\1\255\255\255Longueur:\1\160\153\222 17.7 Unités
+!I!\1\255\255\255Lunghezza totale:\1\160\153\222 17,7 Unitï¿½
+!F!\1\255\255\255Longueur:\1\160\153\222 17.7 Unitï¿½s
 
 !=!\1\255\255\255Height: \1\160\153\222 7.05 Units
-!G!\1\255\255\255Höhe: \1\160\153\222 7.05 Einheiten
+!G!\1\255\255\255Hï¿½he: \1\160\153\222 7.05 Einheiten
 !S!\1\255\255\255Altura: \1\160\153\222 7.05 Unidades 
-!I!\1\255\255\255Altezza: \1\160\153\222 7,05 Unità
-!F!\1\255\255\255Hauteur: \1\160\153\222 7.05 Unités
+!I!\1\255\255\255Altezza: \1\160\153\222 7,05 Unitï¿½
+!F!\1\255\255\255Hauteur: \1\160\153\222 7.05 Unitï¿½s
 
 !=!\1\255\255\255Weight Empty: \1\160\153\222 16,159 Lbs
 !G!\1\255\255\255Leergewicht: \1\160\153\222 8.079 kg
-!S!\1\255\255\255Peso vacío: \1\160\153\222 8.079 kg 
+!S!\1\255\255\255Peso vacï¿½o: \1\160\153\222 8.079 kg 
 !I!\1\255\255\255Peso a vuoto: \1\160\153\222 8.079 kg
-!F!\1\255\255\255Poids à vide: \1\160\153\222 8.079 kg
+!F!\1\255\255\255Poids ï¿½ vide: \1\160\153\222 8.079 kg
 
 !/!874 Enabled Controls: (used in training mission)
 !=!Enabled Controls:
@@ -6174,31 +6181,31 @@
 
 !/!875 Forward (used in training mission)
 !=!Forward
-!G!Vorwärts
+!G!Vorwï¿½rts
 !S!Avanzar
 !I!Avanti
 !F!Avant
 
 !/!876 Reverse (used in training mission)
 !=!Reverse
-!G!Rückwärts
+!G!Rï¿½ckwï¿½rts
 !S!Reversa
 !I!Indietro
-!F!Arrière
+!F!Arriï¿½re
 
 !/!877 Slide Left (used in training mission)
 !=!Slide Left
 !G!Nach links gleiten
 !S!Deslice Izq
 !I!Scivola a sinistra
-!F!Glisser à gauche
+!F!Glisser ï¿½ gauche
 
 !/!878 Slide Right (used in training mission)
 !=!Slide Right
 !G!Nach rechts gleiten
 !S!Deslice Der
 !I!Scivola a destra
-!F!Glisser à droite
+!F!Glisser ï¿½ droite
 
 !/!879 Slide Up (used in training mission)
 !=!Slide Up
@@ -6217,7 +6224,7 @@
 !/!881 Pitch Up (used in training mission)
 !=!Pitch Up
 !G!Nach oben neigen
-!S!Naríz arriba
+!S!Narï¿½z arriba
 !I!Inclina in alto
 !F!cabrer
 
@@ -6233,14 +6240,14 @@
 !G!Nach links drehen
 !S!Girar a izq
 !I!Vira a sinistra
-!F!cap à gauche
+!F!cap ï¿½ gauche
 
 !/!884 Heading Right (used in training mission)
 !=!Heading Right
 !G!Nach rechts drehen
 !S!Girar a der
 !I!Vira a destra
-!F!cap à droite
+!F!cap ï¿½ droite
 
 !/!885 Bank Left (used in training mission)
 !=!Bank Left
@@ -6258,14 +6265,14 @@
 
 !/!887 Primary Weapon (used in training mission)
 !=!Primary Weapon
-!G!Primärwaffe
+!G!Primï¿½rwaffe
 !S!Arma primaria
 !I!Arma principale
 !F!Arme primaire
 
 !/!888 Secondary Weapon (used in training mission)
 !=!Secondary Weapon
-!G!Sekundärwaffe
+!G!Sekundï¿½rwaffe
 !S!Arma secundaria
 !I!Arma secondaria
 !F!Arme secondaire
@@ -6279,10 +6286,10 @@
 
 !/!890 Reliable buffer overrun
 !=!Reliable buffer overrun
-!G!Zuverl. Pufferüberlauf
+!G!Zuverl. Pufferï¿½berlauf
 !S!Memoria intermedia excedida
 !I!Memoria temporanea esaurita
-!F!Dépassement de tampon
+!F!Dï¿½passement de tampon
 
 !/!891 Quick save game help text (help dialog)
 !=!Quick Save Game

--- a/win32/WinController.cpp
+++ b/win32/WinController.cpp
@@ -898,7 +898,15 @@ float gameWinController::get_axis_value(sbyte controller, ubyte axis, ct_format 
     return val;
   }
 
-  if ((Current_pilot.mouselook_control) && (GAME_MODE == GetFunctionMode())) {
+  if ((Current_pilot.mouselook_control == 2) && (GAME_MODE == GetFunctionMode())) {
+    if (axis == CT_Y_AXIS)
+      val = -val;
+
+    if (invert)
+      val = -val;
+  }
+
+  if ((Current_pilot.mouselook_control == 1) && (GAME_MODE == GetFunctionMode())) {
     // Don't do mouselook controls if they aren't enabled in multiplayer
     if ((Game_mode & GM_MULTI) && (!(Netgame.flags & NF_ALLOW_MLOOK)))
       return val;


### PR DESCRIPTION
Mouselook doesn't quite preserve inertia, and feels jarring to use as a non inverted-Y user. This PR fixes that, preserving the old mouselook mode and adding a new "Inverted Flight Sim" mode. The video illustrates the differences between current mouselook and the new mode.

Problem is that by adding it as a new option it needs to do something about the strings being included with the game data. Oops.

https://github.com/kevinbentley/Descent3/assets/391382/bc8a1e67-8b64-4380-a54d-a8f02556caca

