### PR TITLE
Use __aarch64__ instead of __arm64__ for Linux builds

### DIFF
--- a/lib/linux/linux_fix.h
+++ b/lib/linux/linux_fix.h
@@ -47,7 +47,7 @@ inline int _filelength(int fd) {
 #define strcmpi(a, b) stricmp(a, b)
 #define strcmpni(a, b, c) strnicmp(a, b, c)
 #define _chmod(a, b) chmod(a, b)
-#if defined(__arm64__)
+#if defined(__aarch64__)
 #define _finite(a) isfinite(a)
 #else
 #define _finite(a) finite(a)

--- a/libmve/mveasm.cpp
+++ b/libmve/mveasm.cpp
@@ -2055,7 +2055,7 @@ void MVE_gfxSetSplit(unsigned line);
 
 #if defined(__LINUX__)
 
-#if !defined(MACOSXPPC) && !defined(__arm64__)
+#if !defined(MACOSXPPC) && !defined(__aarch64__)
 
 #define int3 __asm__ __volatile__("int $3");
 #else


### PR DESCRIPTION
- Fixes a build error on M1 Linux, `unknown mnemonic int -- int $3`, in mveasm.cpp