### PR TITLE
Fix HOG file entry parser in 64 bit architectures

### DIFF
--- a/lib/hogfile.h
+++ b/lib/hogfile.h
@@ -57,7 +57,7 @@ typedef struct tHogFileEntry {
   char name[HOG_FILENAME_LEN]; // file name
   unsigned flags;              // extra info
   unsigned len;                // length of file
-  unsigned long timestamp;     // time of file.
+  unsigned timestamp;     // time of file.
 } tHogFileEntry;
 
 #define HOGMAKER_ERROR 0       // Incorrect number of files passed in


### PR DESCRIPTION
timestamp is 4 bytes in the file, but is read as an 8-bytes long when built on 64 bit architectures, screwing up the read offset