### PR TITLE
Allow user to specify additional compiler flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,8 @@ IF (UNIX)
     SET(EXTRA_CXX_FLAGS "-fpermissive")
   ENDIF()
 
-  SET(CMAKE_CXX_FLAGS "-Wno-write-strings -Wno-multichar ${BITS} ${EXTRA_CXX_FLAGS}")
-  SET(CMAKE_C_FLAGS "${BITS}")
+  STRING(APPEND CMAKE_CXX_FLAGS " -Wno-write-strings -Wno-multichar ${BITS} ${EXTRA_CXX_FLAGS}")
+  STRING(APPEND CMAKE_C_FLAGS " ${BITS}")
 
   FIND_PACKAGE(SDL REQUIRED)
   IF (APPLE)


### PR DESCRIPTION
I’m trying to compile Descent 3 on NixOS, but when I run `cmake --build <path>`, I get this error:

```
/home/jayman/Documents/Home/VC/Git/Partially mine/Descent3/repo/Descent3/multi_connect.cpp: In function 'int TryToJoinServer(network_address*)':
/home/jayman/Documents/Home/VC/Git/Partially mine/Descent3/repo/Descent3/multi_connect.cpp:358:16: error: format not a string literal and no format arguments [-Werror=format-security]
  358 |         sprintf(str, TXT(Join_response_strings[Ok_to_join]));
      |         ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Eventually, we should actually fix that `sprintf` call (and any other calls that would trigger format security warnings), but it would be nice if users could just temporarily ignore stuff like that.

This commit makes it so that users can set custom complier flags by doing this:

```console
$ cmake \
	--preset <preset> \
	-B build \
	-DCMAKE_C_FLAGS=<additional-c-flags> \
	-DCMAKE_CXX_FLAGS=<additional-cxx-flags>
$ cmake --build build
```
