### PR TITLE
Add Linux and D3 specific .gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -401,3 +401,10 @@ FodyWeavers.xsd
 .idea/
 cmake-build-*
 
+# Linux stuff
+build
+*.so
+
+
+# D3 specific
+*.hog


### PR DESCRIPTION
Ignore these:
`build/` (CMake build directory)
`*.so` (Linux)
`*.hog` (D3)