### PR TITLE
Accurately find the linux artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
           sudo dpkg --add-architecture i386
           sudo apt update
           sudo apt install -y --no-install-recommends \
-            ninja make cmake g++ libsdl1.2-dev libsdl-image1.2-dev libncurses-dev \
+            ninja-build make cmake g++ libsdl1.2-dev libsdl-image1.2-dev libncurses-dev \
             libxext6:i386  # for ./scripts/hogutils/hogUtils-i686 binary
           mkdir ~/Descent3
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,5 +56,5 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ matrix.os.preset == 'linux' }}
         with:
-            name: build_${{ matrix.os.runner }}_${{ matrix.build_type }}_Linux
-            path: ${{ github.workspace }}/build/Descent3/
+            name: build_${{ matrix.os.runner }}_${{ matrix.build_type }}
+            path: ${{ github.workspace }}/build/Descent3/Descent3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,8 +45,16 @@ jobs:
       - name: Build
         run: cmake --build ${{ github.workspace }}/build --config ${{ matrix.build_type }}
 
-      - name: Upload Artifacts
+      - name: Upload Artifacts (Non-Linux)
         uses: actions/upload-artifact@v4
+        if: ${{ matrix.os.preset != 'linux' }}
         with:
           name: build_${{ matrix.os.runner }}_${{ matrix.build_type }}
-          path: ${{ github.workspace }}/build/Descent3/${{ matrix.os.preset == 'linux' ? '':matrix.build_type }}
+          path: ${{ github.workspace }}/build/Descent3/${{ matrix.build_type }}
+
+      - name: Upload Artifacts (Linux)
+        uses: actions/upload-artifact@v4
+        if: ${{ matrix.os.preset == 'linux' }}
+        with:
+            name: build_${{ matrix.os.runner }}_${{ matrix.build_type }}_Linux
+            path: ${{ github.workspace }}/build/Descent3/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,16 +45,8 @@ jobs:
       - name: Build
         run: cmake --build ${{ github.workspace }}/build --config ${{ matrix.build_type }}
 
-      - name: Upload Artifacts (Non-Linux)
+      - name: Upload Artifacts
         uses: actions/upload-artifact@v4
-        if: ${{ matrix.os.preset != 'linux' }}
         with:
           name: build_${{ matrix.os.runner }}_${{ matrix.build_type }}
           path: ${{ github.workspace }}/build/Descent3/${{ matrix.build_type }}
-
-      - name: Upload Artifacts (Linux)
-        uses: actions/upload-artifact@v4
-        if: ${{ matrix.os.preset == 'linux' }}
-        with:
-            name: build_${{ matrix.os.runner }}_${{ matrix.build_type }}
-            path: ${{ github.workspace }}/build/Descent3/Descent3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
           sudo dpkg --add-architecture i386
           sudo apt update
           sudo apt install -y --no-install-recommends \
-            make cmake g++ libsdl1.2-dev libsdl-image1.2-dev libncurses-dev \
+            ninja make cmake g++ libsdl1.2-dev libsdl-image1.2-dev libncurses-dev \
             libxext6:i386  # for ./scripts/hogutils/hogUtils-i686 binary
           mkdir ~/Descent3
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,4 +49,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: build_${{ matrix.os.runner }}_${{ matrix.build_type }}
-          path: ${{ github.workspace }}/build/Descent3/${{ matrix.build_type }}
+          path: ${{ github.workspace }}/build/Descent3/${{ matrix.os.preset == 'linux' ? '':matrix.build_type }}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -26,6 +26,7 @@
         }
         , {
             "name": "linux"
+            , "generator": "Ninja Multi-Config",
             , "condition": {
                 "type": "equals"
                 , "lhs": "${hostSystemName}"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -26,7 +26,7 @@
         }
         , {
             "name": "linux"
-            , "generator": "Ninja Multi-Config",
+            , "generator": "Ninja Multi-Config"
             , "condition": {
                 "type": "equals"
                 , "lhs": "${hostSystemName}"


### PR DESCRIPTION
This workflow excludes the build_type matrix when searching for the linux artifact path.