### PR TITLE
enable stricter MSVC warnings, fix some of them

### DIFF
--- a/2dlib/font.cpp
+++ b/2dlib/font.cpp
@@ -577,7 +577,7 @@ void grFont::translate_mono_char(grSurface *sf, int x, int y, int index, gr_font
 
 int grFont::draw_char(grSurface *sf, int x, int y, int ch, tCharProperties *chprop) {
   gr_font_record *ft;
-  int next_x, width, index;
+  int next_x = 0, width, index;
 
   ASSERT(m_FontHandle > -1);
   if ((ch < min_ascii()) || (ch > max_ascii()))
@@ -615,7 +615,7 @@ int grFont::draw_char(grSurface *sf, int x, int y, int ch, tCharProperties *chpr
 
 int grFont::draw_char(grSurface *sf, int x, int y, int ch, int sx, int sy, int sw, int sh, tCharProperties *chprop) {
   gr_font_record *ft;
-  int next_x, width, index;
+  int next_x = 0, width, index;
 
   ASSERT(m_FontHandle > -1);
   if ((ch < min_ascii()) || (ch > max_ascii()))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ ENDIF()
 IF (WIN32)
 	SET(D3_GAMEDIR "c:/games/Descent3/")	
 	set (CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH} "lib/win" "lib/win/directx")
-	SET(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /Gm /EHsc /RTC1 /W3 /nologo /c /ZI /TP /errorReport:prompt")
+	SET(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /EHsc /RTC1 /W3 /nologo /c /Zi /TP /errorReport:prompt")
 	SET(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /GL /FD /EHsc /W3 /nologo /c /Zi /TP /errorReport:prompt")
 	
 	SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /SAFESEH:NO /SUBSYSTEM:WINDOWS /NODEFAULTLIB:LIBC")
@@ -65,6 +65,19 @@ IF (WIN32)
 	FIND_LIBRARY(DINPUT_LIBRARY NAMES dinput "${CMAKE_SOURCE_DIR}/lib/win" "${CMAKE_SOURCE_DIR}/lib/win/directx")
 	FIND_LIBRARY(DXGUID_LIBRARY NAMES dxguid "${CMAKE_SOURCE_DIR}/lib/win" "${CMAKE_SOURCE_DIR}/lib/win/directx")
 	FIND_LIBRARY(DDRAW_LIBRARY NAMES ddraw "${CMAKE_SOURCE_DIR}/lib/win" "${CMAKE_SOURCE_DIR}/lib/win/directx")
+
+	if (MSVC AND CMAKE_CXX_SIMULATE_ID STREQUAL "")
+		add_compile_options("/we4150")  # deletion of pointer to incomplete type 'type'; no destructor called
+#		add_compile_options("/we4305")  # truncation from 'X' to 'Y'
+		add_compile_options("/we4474")  # too many arguments passed for format string
+		add_compile_options("/we4700")  # uninitialized local variable 'X' used
+		add_compile_options("/we4804")  # unsafe use of type 'bool' in operation
+		add_compile_options("/we4806")  # unsafe operation: no value of type 'bool' promoted to type 'int' can equal the given constant
+		add_compile_options("/we4473")  # not enough arguments passed for format string
+		add_compile_options("/we4477")  # format string requires argument of type X but variadic argument Y has type Z
+		add_compile_options("/we4715")  # 'function' : not all control paths return a value
+		add_compile_options("/we4834")  # discarding return value of function with [[nodiscard]] attribute
+	endif()
 ENDIF ()
 
 MESSAGE("Install will copy files to ${D3_GAMEDIR}")

--- a/Descent3/multi_external.h
+++ b/Descent3/multi_external.h
@@ -99,6 +99,7 @@
 #include "networking.h"
 #include "descent.h" //for MSN_NAMELEN
 #include "byteswap.h"
+#include <cassert>
 
 #define NETGAME_NAME_LEN 32
 #define NETGAME_SCRIPT_LEN 32
@@ -286,9 +287,10 @@ inline void MultiAddFloat(float element, ubyte *data, int *count) {
 }
 
 inline void MultiAddString(char *str, ubyte *data, int *count) {
-  ubyte len = strlen(str) + 1;
+  size_t len = strlen(str) + 1;
+  assert(len <= 0xFF);
 
-  MultiAddByte(len, data, count);
+  MultiAddByte((ubyte)len, data, count);
   memcpy(&data[*count], str, len);
   *count += len;
 }

--- a/dd_sndlib/dsound3d.cpp
+++ b/dd_sndlib/dsound3d.cpp
@@ -537,7 +537,7 @@ void sb_buffered_loop_step(win_llsSystem *lls, sound_buffer_info *sb, int force_
 
   pos_state old_pos_state;
   float old_pan;
-  float old_volume;
+  float old_volume = 0.0f;
 
   ASSERT(lls->m_mixer_type != SOUND_MIXER_SOFTWARE_16 && lls->m_mixer_type != SOUND_MIXER_NONE);
 

--- a/music/omflex.cpp
+++ b/music/omflex.cpp
@@ -306,7 +306,7 @@ bool OutrageMusicSeq::LoadTheme(const char *file) {
 
       case OMFCMD_COMPARE: {
         tMusicVal val;
-        sscanf(operand, "r%d", &val);
+        sscanf(operand, "r%hd", &val);
         ADD_NEW_INS_NUM(OMFCMD_COMPARE, val);
         break;
       }


### PR DESCRIPTION
I've added a list of "safe" warnings as errors I have on some of my projects (the list is longer, but these ones should be good for a start). The truncation warning should also be enabled IMHO, but there are a few instances where it happens (`snd8to16.h` has invalid conversions) and I haven't checked how those should look like yet.