### PR TITLE
Quiet Clang Static Analyzer warnings.

### DIFF
--- a/2dlib/memsurf.cpp
+++ b/2dlib/memsurf.cpp
@@ -134,6 +134,7 @@ bool gr_mem_surf_Create(ddgr_surface *sf) {
   mem_bitmap *bm;
 
   bm = new mem_bitmap;
+  memset(bm, 0, sizeof(mem_bitmap));
 
   switch (sf->bpp) {
   case BPP_16:

--- a/2dlib/surface.cpp
+++ b/2dlib/surface.cpp
@@ -452,7 +452,7 @@ char *grSurface::lock(int *rowsize) {
 
 /* do lock based off of x,y offsets */
 char *grSurface::lock(int x, int y, int *rowsize) {
-  bool grerr;
+  bool grerr = false;
 
   ASSERT(m_SurfInit);
 

--- a/Descent3/AIGoal.cpp
+++ b/Descent3/AIGoal.cpp
@@ -1399,7 +1399,7 @@ bool GoalIsGoalEnabled(object *obj, int goal_index) {
   ASSERT(goal_index >= 0 && goal_index < MAX_GOALS);
 
   if (OBJGOAL(cur_goal)) {
-    object *gobj;
+    object *gobj = NULL;
 
     if (cur_goal->flags & GF_OBJ_IS_TARGET) {
       gobj = ObjGet(obj->ai_info->target_handle);

--- a/Descent3/BriefingParse.cpp
+++ b/Descent3/BriefingParse.cpp
@@ -295,7 +295,7 @@ int CBriefParse::ParseBriefing(char *filename) {
   // here until a $endtext is hit
   char title_buf[128];
   bool reading_text = false;
-  tTextBufferDesc text_buffer_desc;
+  tTextBufferDesc text_buffer_desc = {};
   text_buffer_desc.text_id = -1; // id # for current textblock
   text_buffer_desc.teffect = tfxNONE;
 

--- a/Descent3/LoadLevel.cpp
+++ b/Descent3/LoadLevel.cpp
@@ -2506,7 +2506,7 @@ int ReadRoom(CFILE *ifile, room *rp, int version) {
     rp->mirror_face = -1;
 
   if ((rp->flags & RF_DOOR)) {
-    int doornum, flags = 0, keys = 0, position = 0.0;
+    int doornum = 0, flags = 0, keys = 0, position = 0.0;
 
     if (version >= 28 && version <= 32) {
       doornum = door_xlate[cf_ReadInt(ifile)];
@@ -2747,7 +2747,7 @@ void ReadLightmapChunk(CFILE *fp, int version) {
 
   int nummaps;
   int i, t;
-  ushort *ded_dummy_data;
+  ushort *ded_dummy_data = NULL;
 
   if (Dedicated_server) {
     ded_dummy_data = (ushort *)mem_malloc(128 * 128 * 2);

--- a/Descent3/WeaponFire.cpp
+++ b/Descent3/WeaponFire.cpp
@@ -2207,7 +2207,7 @@ float Last_fusion_damage_time = 0;
 // Does that crazy fusion effect, including damaging/shaking your ship
 void DoFusionEffect(object *objp, int weapon_type) {
   float norm;
-  int move;
+  int move = 0;
 
   ASSERT(objp->type == OBJ_PLAYER);
   ASSERT((weapon_type == PW_PRIMARY) || (weapon_type == PW_SECONDARY));

--- a/Descent3/aipath.cpp
+++ b/Descent3/aipath.cpp
@@ -116,7 +116,7 @@ bool AIFindAltPath(object *obj, int i, int j, float *dist) {
       if (BOA_LockedDoor(obj, next_room))
         continue;
 
-      int next_portal;
+      int next_portal = 0;
 
       if (BOA_INDEX(next_room) != BOA_INDEX(cur_node->roomnum)) {
         next_portal = BOA_DetermineStartRoomPortal(BOA_INDEX(next_room), NULL, BOA_INDEX(cur_node->roomnum), NULL,
@@ -757,7 +757,7 @@ done:
 
 void AIGenerateAltBOAPath(vector *start_pos, vector *end_pos, ai_path_info *aip, int *slot, int *cur_node, int handle) {
   int x;
-  vector *pos;
+  vector *pos = NULL;
 
   for (x = 0; x < AIAltPathNumNodes - 1; x++) {
     int cur_room = AIAltPath[x];

--- a/Descent3/bsp.cpp
+++ b/Descent3/bsp.cpp
@@ -301,7 +301,7 @@ int ClassifyPolygon(bspplane *plane, bsppolygon *poly) {
 // Tries to split a polygon across a plane
 int SplitPolygon(bspplane *plane, bsppolygon *testpoly, bsppolygon **frontpoly, bsppolygon **backpoly) {
   float dists[256], t;
-  int numvert, numfront, numback, i, codes[256];
+  int numvert, numfront, numback, i, codes[256] = {};
   vector *frontvert[256], *backvert[256], *polyvert[256];
   vector *vertptr1, *vertptr2;
   vector delta, *newvert[256];

--- a/Descent3/ctlconfig.cpp
+++ b/Descent3/ctlconfig.cpp
@@ -494,7 +494,7 @@ void key_cfg_screen::process(int res) {
 }
 void key_cfg_screen::realize() {
   // create controls
-  int i, x, y;
+  int i, x = 0, y;
   t_cfg_element *cfg_elem = &Cfg_key_elements[0];
   m_reset_btn.Create(m_menu, UID_RESETDEFAULTS, TXT_RESETTODEFAULT, KEYCFG_EXTRAS_X + m_sheet->X(),
                      KEYCFG_EXTRAS_Y + m_sheet->Y(), NEWUI_BTNF_LONG);
@@ -657,7 +657,7 @@ void joy_cfg_screen::process(int res) {
 }
 
 void joy_cfg_screen::realize() {
-  int i, x, y;
+  int i, x = 0, y;
   t_cfg_element *cfg_elem = &Cfg_joy_elements[0];
 #ifdef MACINTOSH
 #else

--- a/Descent3/debuggraph.cpp
+++ b/Descent3/debuggraph.cpp
@@ -408,7 +408,7 @@ void tGraphNode::Render(void) {
     return;
   rend_SetFlatColor(color);
 
-  int last_x, last_y, y;
+  int last_x, last_y = 0, y;
   int index = first_pos;
   int count = num_items_stored;
   count--;

--- a/Descent3/dedicated_server.cpp
+++ b/Descent3/dedicated_server.cpp
@@ -702,8 +702,8 @@ void ParseLine(char *srcline, char *command, char *operand, int cmdlen, int oprl
 // Called once per frame for the dedicated server
 void DoDedicatedServerFrame() {
   char str[255];
-  char command[255]; // operand
-  char operand[255]; // operand
+  char command[255] = {}; // operand
+  char operand[255];      // operand
 
   ListenDedicatedSocket();
   DedicatedReadTelnet();
@@ -973,8 +973,8 @@ void DedicatedReadTelnet(void) {
           }
           send(conn->sock, "\r\n", strlen("\r\n"), 0);
           if (conn->validated) {
-            char command[255]; // operand
-            char operand[255]; // operand
+            char command[255] = {}; // operand
+            char operand[255];      // operand
 
             if (!stricmp(conn->input, "logout")) {
               // log the connection out

--- a/Descent3/gamecinematics.cpp
+++ b/Descent3/gamecinematics.cpp
@@ -1264,7 +1264,7 @@ void Cinematic_DrawText(void) {
   case GCF_TEXT_WIPEIN: {
     // first 1/3 is alpha in
     // last 2/3 is solid
-    ubyte alpha;
+    ubyte alpha = 0;
 
     if (perc > 0.33f) {
       // middle 1/3

--- a/Descent3/huddisplay.cpp
+++ b/Descent3/huddisplay.cpp
@@ -351,7 +351,7 @@ void RenderHUDInventory(tHUDItem *item) {
     return;
 
   int y;
-  float img_w;
+  float img_w = 0;
 
   if (cur_sel != -1) {
     ASSERT(cur_sel < MAX_UNIQUE_INVEN_ITEMS);
@@ -689,7 +689,7 @@ void RenderHUDSecondary(tHUDItem *item) {
 
 void RenderHUDShipStatus(tHUDItem *item) {
   float clk_time_frame, inv_time_frame;
-  ubyte clk_alpha, inv_alpha;
+  ubyte clk_alpha = 0, inv_alpha;
 
   //	render text status
   if (Objects[Players[Player_num].objnum].effect_info->type_flags & EF_CLOAKED) {

--- a/Descent3/levelgoal.cpp
+++ b/Descent3/levelgoal.cpp
@@ -722,9 +722,9 @@ bool levelgoals::SaveLevelGoalInfo(CFILE *fptr) {
     int len;
     int num_items;
     int j;
-    int priority;
-    char g_list;
-    int status;
+    int priority = 0;
+    char g_list = 0;
+    int status = 0;
 
     Level_goals.GoalStatus(i, LO_GET_SPECIFIED, &status);
     cf_WriteInt(fptr, status);
@@ -767,7 +767,7 @@ bool levelgoals::SaveLevelGoalInfo(CFILE *fptr) {
     num_items = Level_goals.GoalGetNumItems(i);
     cf_WriteShort(fptr, num_items);
     for (j = 0; j < num_items; j++) {
-      char type;
+      char type = 0;
       int handle;
       bool f_done;
 

--- a/Descent3/newui_core.cpp
+++ b/Descent3/newui_core.cpp
@@ -1646,7 +1646,7 @@ void newuiSheet::Unrealize() {
 
 //	refreshes gadget states with values passed to the pointers returned by the below functions.
 void newuiSheet::UpdateChanges() {
-  int i, first_radio_index;
+  int i, first_radio_index = 0;
 
   ASSERT(m_realized);
 

--- a/Descent3/pilot.cpp
+++ b/Descent3/pilot.cpp
@@ -2431,7 +2431,7 @@ bool UpdateGraphicsListbox(tCustomListInfo *cust_bmps, newuiListBox *lb, char *s
   // get a list of custom textures
   int count = 0;
   bool ok_to_get_files;
-  int total_files;
+  int total_files = 0;
 
   // build list
   char oldpath[_MAX_PATH];

--- a/Descent3/render.cpp
+++ b/Descent3/render.cpp
@@ -919,7 +919,7 @@ void BuildRoomListSub(int start_room_num, clip_wnd *wnd, int depth) {
       for (i = 0; i < num_points; i++) {
         g3_ProjectPoint(&Combined_portal_points[i]);
       }
-      int left, top, right, bottom;
+      int left = 0, top = 0, right = 0, bottom = 0;
       clip_wnd combine_wnd;
       combine_wnd.right = combine_wnd.bot = 0.0;
       combine_wnd.left = Render_width;
@@ -1567,7 +1567,7 @@ void RenderFogFaces(room *rp) {
       g3Point *p = &pointbuffer[vn];
       pointlist[vn] = p;
 
-      float mag;
+      float mag = 0;
 
       if (Room_fog_plane_check == 0) {
         // Outside of the room

--- a/Descent3/robotfire.cpp
+++ b/Descent3/robotfire.cpp
@@ -116,7 +116,7 @@ void WBFireBattery(object *obj, otype_wb_info *static_wb, int poly_wb_index, int
   int weapon_obj;
   int must_send = 0;
   int first = 1;
-  int saved_weapon_id;
+  int saved_weapon_id = 0;
 
   unsigned char fire_mask;
 

--- a/bitmap/bitmain.cpp
+++ b/bitmap/bitmain.cpp
@@ -707,7 +707,7 @@ int bm_AllocLoadFileBitmap(const char *fname, int mipped, int format) {
   }
 
   char name[BITMAP_NAME_LEN];
-  int n, src_bm;
+  int n, src_bm = 0;
   int old_used;
   int overlay = 0;
 
@@ -1317,7 +1317,7 @@ void bm_GenerateMipMaps(int handle) {
 
         int rsum, gsum, bsum, asum;
         rsum = gsum = bsum = asum = 0;
-        ushort destpix;
+        ushort destpix = 0;
         if (GameBitmaps[handle].format == BITMAP_FORMAT_1555) {
           for (int y = 0; y < 2; y++)
             for (int x = 0; x < 2; x++) {

--- a/bitmap/iff.cpp
+++ b/bitmap/iff.cpp
@@ -181,7 +181,7 @@ int bm_iff_parse_bmhd(CFILE *ifile, uint len, iff_bitmap_header *bmheader) {
 //  the buffer pointed to by raw_data is stuffed with a pointer to decompressed pixel data
 int bm_iff_parse_body(CFILE *ifile, int len, iff_bitmap_header *bmheader) {
   ubyte *p = bmheader->raw_data;
-  int width, depth, done = 0;
+  int width = 0, depth = 0, done = 0;
 
   if (bmheader->type == TYPE_PBM) {
     width = bmheader->w;

--- a/cfile/InfFile.cpp
+++ b/cfile/InfFile.cpp
@@ -125,7 +125,7 @@ int InfFile::ParseLine(char *operand, int oprlen) {
 
   //	tokenize line.
   char command[32]; // Command read from line.
-  char *opr, *cmd;
+  char *opr = NULL, *cmd;
   int retval = INFFILE_NULL;
 
   if (strlen(m_lineptr) == 0)

--- a/dd_lnxsound/mixer.cpp
+++ b/dd_lnxsound/mixer.cpp
@@ -126,7 +126,7 @@ void software_mixer::StreamMixer(char *ptr, int len) {
       int samples_played = cur_buf->play_info->m_samples_played;
       short *sample_16bit;
       unsigned char *sample_8bit;
-      int np_sample_length;
+      int np_sample_length = 0;
       int sample_length;
       int loop_start;
       int loop_end;

--- a/ddio_lnx/sdljoy.cpp
+++ b/ddio_lnx/sdljoy.cpp
@@ -229,7 +229,7 @@ void joy_GetRawPos(tJoystick joy, tJoyPos *pos) {
 }
 
 static inline unsigned int map_hat(Uint8 value) {
-  unsigned int mapped;
+  unsigned int mapped = 0;
 
   switch (value) {
   case SDL_HAT_CENTERED:

--- a/libmve/lnxdsound.cpp
+++ b/libmve/lnxdsound.cpp
@@ -596,7 +596,7 @@ static void LinuxSoundMixWithVolume(LnxSoundBuffer *dsb, unsigned char *buf, uns
 }
 
 static unsigned int LinuxSoundMixNormalize(LnxSoundBuffer *dsb, unsigned char *buf, unsigned int len) {
-  unsigned int i, size, ipos, ilen, fieldL, fieldR;
+  unsigned int i, size, ipos, ilen, fieldL = 0, fieldR = 0;
   unsigned char *ibp, *obp;
   unsigned int iAdvance = dsb->wfx.nBlockAlign;
   unsigned int oAdvance = LnxBuffers[0]->wfx.nBlockAlign;

--- a/lnxcontroller/lnxcontroller.cpp
+++ b/lnxcontroller/lnxcontroller.cpp
@@ -1091,7 +1091,7 @@ float lnxgameController::get_button_value(sbyte controller, ct_format format, ub
 float lnxgameController::get_axis_value(sbyte controller, ubyte axis, ct_format format, bool invert) {
   struct lnxgameController::t_controller *ctldev;
   float val = (float)0.0;
-  float normalizer, axisval, nullzone; //, senszone;
+  float normalizer, axisval = 0, nullzone; //, senszone;
 
   if (controller <= NULL_LNXCONTROLLER || controller >= CT_MAX_CONTROLLERS) {
     return 0.0f;

--- a/manage/generic.cpp
+++ b/manage/generic.cpp
@@ -1331,7 +1331,7 @@ int mng_ReadGenericPage(CFILE *infile, mngs_generic_page *genericpage) {
   int done = 0;
   char command;
   ushort len;
-  int i, temp, version, t;
+  int i, temp, version = 0, t;
 
   if (!Old_table_method)
     return mng_ReadNewGenericPage(infile, genericpage);

--- a/misc/error.cpp
+++ b/misc/error.cpp
@@ -249,7 +249,7 @@ void OutrageMessageBox(char *str, ...) {
 int OutrageMessageBox(int type, char *str, ...) {
   char buf[BUF_LEN];
   va_list arglist;
-  int os_flags;
+  int os_flags = 0;
   int nchars;
 
   va_start(arglist, str);

--- a/music/omflex.cpp
+++ b/music/omflex.cpp
@@ -109,7 +109,7 @@ bool OutrageMusicSeq::LoadTheme(const char *file) {
   char operand[INFFILE_LINELEN]; // operand
   int theme_type;
   music_ins temp_ins_buf[MAX_MUSIC_INSTRUCTIONS];
-  int temp_ins_idx;
+  int temp_ins_idx = 0;
   short cur_region;
   struct {
     char *name;

--- a/music/streamer.cpp
+++ b/music/streamer.cpp
@@ -51,7 +51,7 @@ oms_stream::~oms_stream() {}
 
 // processes a stream's events.
 void oms_stream::Process(float frmtime) {
-  oms_q_evt evt, evt2; // event for use
+  oms_q_evt evt, evt2 = {}; // event for use
 
   if (m_timer > 0.0f)
     m_timer -= frmtime;

--- a/netcon/inetfile/CFtp.cpp
+++ b/netcon/inetfile/CFtp.cpp
@@ -164,7 +164,7 @@ CFtpGet::CFtpGet(char *URL, char *localfile, char *Username, char *Password) {
   // then keep reading until you find the first /
   // when you found it, you have the host and dir
   char *filestart = NULL;
-  char *dirstart;
+  char *dirstart = NULL;
   for (int i = strlen(pURL); i >= 0; i--) {
     if (pURL[i] == '/') {
       if (!filestart) {

--- a/netcon/inetfile/Chttpget.cpp
+++ b/netcon/inetfile/Chttpget.cpp
@@ -218,7 +218,7 @@ void ChttpGet::PrepSocket(char *URL) {
   // then keep reading until you find the first /
   // when you found it, you have the host and dir
   char *filestart = NULL;
-  char *dirstart;
+  char *dirstart = NULL;
   for (int i = strlen(pURL); i >= 0; i--) {
     if (pURL[i] == '/') {
       if (!filestart) {
@@ -586,7 +586,7 @@ char *ChttpGet::GetHTTPLine() {
 
 unsigned int ChttpGet::ReadDataChannel() {
   char sDataBuffer[4096]; // Data-storage buffer for the data channel
-  int nBytesRecv;         // Bytes received from the data channel
+  int nBytesRecv = 0;     // Bytes received from the data channel
 
   fd_set wfds;
 

--- a/netcon/inetfile/inetgetfile.cpp
+++ b/netcon/inetfile/inetgetfile.cpp
@@ -205,7 +205,7 @@ BOOL InetGetFile::IsConnecting() {
 }
 
 BOOL InetGetFile::IsReceiving() {
-  int state;
+  int state = 0;
   if (m_bUseHTTP) {
     state = http->GetStatus();
   } else if (ftp) {
@@ -219,7 +219,7 @@ BOOL InetGetFile::IsReceiving() {
 }
 
 BOOL InetGetFile::IsFileReceived() {
-  int state;
+  int state = 0;
   if (m_bUseHTTP) {
     state = http->GetStatus();
   } else if (ftp) {

--- a/netgames/anarchy/anarchy.cpp
+++ b/netgames/anarchy/anarchy.cpp
@@ -809,7 +809,7 @@ void DisplayHUDScores(struct tHUDItem *hitem) {
   ubyte alpha = DMFCBase->ConvertHUDAlpha((ubyte)((DisplayScoreScreen) ? 128 : 255));
   int y = (DMFCBase->GetGameWindowH() / 2) - ((height * 5) / 2);
   int x = 520;
-  ddgr_color color;
+  ddgr_color color = 0;
 
   int rank = 1;
   player_record *pr;

--- a/netgames/entropy/EntropyPackets.cpp
+++ b/netgames/entropy/EntropyPackets.cpp
@@ -143,7 +143,7 @@ void ReceivePickupVirus(ubyte *data) {
 #define RT_BLUENG 5
 
 void SendRoomInfo(int pnum) {
-  char *room_info;
+  char *room_info = NULL;
   int flags, r, i;
   room_info = (char *)malloc(sizeof(char) * RoomCount);
   if (!room_info)

--- a/netgames/monsterball/monsterball.cpp
+++ b/netgames/monsterball/monsterball.cpp
@@ -812,7 +812,7 @@ void OnClientCollide(object *me_obj, object *it_obj, vector *point, vector *norm
     if (it_obj->type == OBJ_PLAYER) {
       // case 1: me_obj = monsterball it_obj = player
       // Result: The player is to pickup the monsterball (as long as it has no owner)
-      int p;
+      int p = 0;
       if (!ValidateOwner(&p, NULL) && p != it_obj->id) {
         ASSERT(it_obj->type == OBJ_PLAYER);
         // HandlePickupPowerball(it_obj);

--- a/netgames/roboanarchy/roboanarchy.cpp
+++ b/netgames/roboanarchy/roboanarchy.cpp
@@ -848,7 +848,7 @@ void DisplayHUDScores(struct tHUDItem *hitem) {
     DLLgrtext_Printf(x - (max_w / 2) - (lwidth / 2), y, buffer);
   }
 
-  int ESortedPlayers[DLLMAX_PLAYERS];
+  int ESortedPlayers[DLLMAX_PLAYERS] = {};
 
   switch (Anarchy_hud_display) {
   case AHD_NONE:

--- a/physics/FindIntersection.cpp
+++ b/physics/FindIntersection.cpp
@@ -2710,8 +2710,8 @@ int fvi_FindIntersection(fvi_query *fq, fvi_info *hit_data, bool no_subdivision)
 
       // Number of whole subdivisions
       int num_subdivisions = vm_VectorDistance(fq->p0, fq->p1) / MIN_LONG_RAY;
-      vector sub_dir; // Direction and magnitude of each subdivision
-      int s_hit_type; // Sub-divided hit type
+      vector sub_dir;     // Direction and magnitude of each subdivision
+      int s_hit_type = 0; // Sub-divided hit type
 
       sub_dir = *fq->p1 - *fq->p0;  // Direction of movement
       vm_NormalizeVector(&sub_dir); // Normalize it

--- a/physics/physics.cpp
+++ b/physics/physics.cpp
@@ -348,7 +348,7 @@ bool PhysicsDoSimRot(object *obj, float frame_time, matrix *orient, vector *rott
   matrix rotmat;
   physics_info *pi;
   bool f_leveling = false;
-  float max_tilt_angle;
+  float max_tilt_angle = 0;
   bool f_newbie_leveling = false;
 
   if (frame_time <= 0.0)

--- a/scripts/BatteriesIncluded.cpp
+++ b/scripts/BatteriesIncluded.cpp
@@ -950,6 +950,7 @@ void STDCALL DestroyInstance(int id, void *ptr) {
   switch (id) {
   case ID_LEVEL_0000:
     delete ((LevelScript_0000 *)ptr);
+    break;
   case ID_TRIGGER_0000:
     delete ((TriggerScript_0000 *)ptr);
     break;

--- a/scripts/BossCamera.cpp
+++ b/scripts/BossCamera.cpp
@@ -445,6 +445,7 @@ void STDCALL DestroyInstance(int id, void *ptr) {
   switch (id) {
   case ID_LEVEL_0000:
     delete ((LevelScript_0000 *)ptr);
+    break;
   case ID_TRIGGER_0000:
     delete ((TriggerScript_0000 *)ptr);
     break;

--- a/scripts/ChrisTest.cpp
+++ b/scripts/ChrisTest.cpp
@@ -463,6 +463,7 @@ void STDCALL DestroyInstance(int id, void *ptr) {
   switch (id) {
   case ID_LEVEL_0000:
     delete ((LevelScript_0000 *)ptr);
+    break;
   case ID_CUSTOM_OBJECT_1004:
     delete ((CustomObjectScript_1004 *)ptr);
     break;

--- a/scripts/GameGauge.cpp
+++ b/scripts/GameGauge.cpp
@@ -523,6 +523,7 @@ void STDCALL DestroyInstance(int id, void *ptr) {
   switch (id) {
   case ID_LEVEL_0000:
     delete ((LevelScript_0000 *)ptr);
+    break;
   case ID_CUSTOM_OBJECT_0877:
     delete ((CustomObjectScript_0877 *)ptr);
     break;

--- a/scripts/Geodomes.cpp
+++ b/scripts/Geodomes.cpp
@@ -498,6 +498,7 @@ void STDCALL DestroyInstance(int id, void *ptr) {
   switch (id) {
   case ID_LEVEL_0000:
     delete ((LevelScript_0000 *)ptr);
+    break;
   case ID_CUSTOM_OBJECT_1081:
     delete ((CustomObjectScript_1081 *)ptr);
     break;

--- a/scripts/HalfPipe.cpp
+++ b/scripts/HalfPipe.cpp
@@ -494,6 +494,7 @@ void STDCALL DestroyInstance(int id, void *ptr) {
   switch (id) {
   case ID_LEVEL_0000:
     delete ((LevelScript_0000 *)ptr);
+    break;
   case ID_TRIGGER_0003:
     delete ((TriggerScript_0003 *)ptr);
     break;

--- a/scripts/InfernalBolt.cpp
+++ b/scripts/InfernalBolt.cpp
@@ -498,6 +498,7 @@ void STDCALL DestroyInstance(int id, void *ptr) {
   switch (id) {
   case ID_LEVEL_0000:
     delete ((LevelScript_0000 *)ptr);
+    break;
   case ID_CUSTOM_OBJECT_0803:
     delete ((CustomObjectScript_0803 *)ptr);
     break;

--- a/scripts/Inversion.cpp
+++ b/scripts/Inversion.cpp
@@ -786,6 +786,7 @@ void STDCALL DestroyInstance(int id, void *ptr) {
   switch (id) {
   case ID_LEVEL_0000:
     delete ((LevelScript_0000 *)ptr);
+    break;
   case ID_CUSTOM_OBJECT_0810:
     delete ((CustomObjectScript_0810 *)ptr);
     break;

--- a/scripts/LEVEL0.cpp
+++ b/scripts/LEVEL0.cpp
@@ -798,6 +798,7 @@ void STDCALL DestroyInstance(int id, void *ptr) {
   switch (id) {
   case ID_LEVEL_0000:
     delete ((LevelScript_0000 *)ptr);
+    break;
   case ID_CUSTOM_OBJECT_3855:
     delete ((CustomObjectScript_3855 *)ptr);
     break;

--- a/scripts/LEVEL15.cpp
+++ b/scripts/LEVEL15.cpp
@@ -2019,6 +2019,7 @@ void STDCALL DestroyInstance(int id, void *ptr) {
   switch (id) {
   case ID_LEVEL_0000:
     delete ((LevelScript_0000 *)ptr);
+    break;
   case ID_CUSTOM_OBJECT_10FD:
     delete ((CustomObjectScript_10FD *)ptr);
     break;

--- a/scripts/Level12.cpp
+++ b/scripts/Level12.cpp
@@ -2413,6 +2413,7 @@ void STDCALL DestroyInstance(int id, void *ptr) {
   switch (id) {
   case ID_LEVEL_0000:
     delete ((LevelScript_0000 *)ptr);
+    break;
   case ID_CUSTOM_OBJECT_09DF:
     delete ((CustomObjectScript_09DF *)ptr);
     break;

--- a/scripts/Level16.cpp
+++ b/scripts/Level16.cpp
@@ -553,6 +553,7 @@ void STDCALL DestroyInstance(int id, void *ptr) {
   switch (id) {
   case ID_LEVEL_0000:
     delete ((LevelScript_0000 *)ptr);
+    break;
   case ID_CUSTOM_OBJECT_4010:
     delete ((CustomObjectScript_4010 *)ptr);
     break;

--- a/scripts/Level6.cpp
+++ b/scripts/Level6.cpp
@@ -1957,6 +1957,7 @@ void STDCALL DestroyInstance(int id, void *ptr) {
   switch (id) {
   case ID_LEVEL_0000:
     delete ((LevelScript_0000 *)ptr);
+    break;
   case ID_CUSTOM_OBJECT_208F:
     delete ((CustomObjectScript_208F *)ptr);
     break;

--- a/scripts/Level9.cpp
+++ b/scripts/Level9.cpp
@@ -1254,6 +1254,7 @@ void STDCALL DestroyInstance(int id, void *ptr) {
   switch (id) {
   case ID_LEVEL_0000:
     delete ((LevelScript_0000 *)ptr);
+    break;
   case ID_CUSTOM_OBJECT_081B:
     delete ((CustomObjectScript_081B *)ptr);
     break;

--- a/scripts/LevelS1.cpp
+++ b/scripts/LevelS1.cpp
@@ -587,6 +587,7 @@ void STDCALL DestroyInstance(int id, void *ptr) {
   switch (id) {
   case ID_LEVEL_0000:
     delete ((LevelScript_0000 *)ptr);
+    break;
   case ID_CUSTOM_OBJECT_0804:
     delete ((CustomObjectScript_0804 *)ptr);
     break;

--- a/scripts/Merc02.cpp
+++ b/scripts/Merc02.cpp
@@ -1973,6 +1973,7 @@ void STDCALL DestroyInstance(int id, void *ptr) {
   switch (id) {
   case ID_LEVEL_0000:
     delete ((LevelScript_0000 *)ptr);
+    break;
   case ID_CUSTOM_OBJECT_1119:
     delete ((CustomObjectScript_1119 *)ptr);
     break;

--- a/scripts/Merc1.cpp
+++ b/scripts/Merc1.cpp
@@ -2683,6 +2683,7 @@ void STDCALL DestroyInstance(int id, void *ptr) {
   switch (id) {
   case ID_LEVEL_0000:
     delete ((LevelScript_0000 *)ptr);
+    break;
   case ID_CUSTOM_OBJECT_2027:
     delete ((CustomObjectScript_2027 *)ptr);
     break;

--- a/scripts/Merc3.cpp
+++ b/scripts/Merc3.cpp
@@ -3421,6 +3421,7 @@ void STDCALL DestroyInstance(int id, void *ptr) {
   switch (id) {
   case ID_LEVEL_0000:
     delete ((LevelScript_0000 *)ptr);
+    break;
   case ID_CUSTOM_OBJECT_0B83:
     delete ((CustomObjectScript_0B83 *)ptr);
     break;

--- a/scripts/Merc4.cpp
+++ b/scripts/Merc4.cpp
@@ -1548,6 +1548,7 @@ void STDCALL DestroyInstance(int id, void *ptr) {
   switch (id) {
   case ID_LEVEL_0000:
     delete ((LevelScript_0000 *)ptr);
+    break;
   case ID_CUSTOM_OBJECT_0811:
     delete ((CustomObjectScript_0811 *)ptr);
     break;

--- a/scripts/Merc6.cpp
+++ b/scripts/Merc6.cpp
@@ -1562,6 +1562,7 @@ void STDCALL DestroyInstance(int id, void *ptr) {
   switch (id) {
   case ID_LEVEL_0000:
     delete ((LevelScript_0000 *)ptr);
+    break;
   case ID_CUSTOM_OBJECT_1006:
     delete ((CustomObjectScript_1006 *)ptr);
     break;

--- a/scripts/Merc7.cpp
+++ b/scripts/Merc7.cpp
@@ -2777,6 +2777,7 @@ void STDCALL DestroyInstance(int id, void *ptr) {
   switch (id) {
   case ID_LEVEL_0000:
     delete ((LevelScript_0000 *)ptr);
+    break;
   case ID_CUSTOM_OBJECT_0885:
     delete ((CustomObjectScript_0885 *)ptr);
     break;

--- a/scripts/Mysterious_Isle.cpp
+++ b/scripts/Mysterious_Isle.cpp
@@ -706,6 +706,7 @@ void STDCALL DestroyInstance(int id, void *ptr) {
   switch (id) {
   case ID_LEVEL_0000:
     delete ((LevelScript_0000 *)ptr);
+    break;
   case ID_CUSTOM_OBJECT_481D:
     delete ((CustomObjectScript_481D *)ptr);
     break;

--- a/scripts/PiccuStation.cpp
+++ b/scripts/PiccuStation.cpp
@@ -1611,6 +1611,7 @@ void STDCALL DestroyInstance(int id, void *ptr) {
   switch (id) {
   case ID_LEVEL_0000:
     delete ((LevelScript_0000 *)ptr);
+    break;
   case ID_CUSTOM_OBJECT_2109:
     delete ((CustomObjectScript_2109 *)ptr);
     break;

--- a/scripts/Polaris.cpp
+++ b/scripts/Polaris.cpp
@@ -508,6 +508,7 @@ void STDCALL DestroyInstance(int id, void *ptr) {
   switch (id) {
   case ID_LEVEL_0000:
     delete ((LevelScript_0000 *)ptr);
+    break;
   case ID_CUSTOM_OBJECT_303F:
     delete ((CustomObjectScript_303F *)ptr);
     break;

--- a/scripts/Quadsomniac.cpp
+++ b/scripts/Quadsomniac.cpp
@@ -547,6 +547,7 @@ void STDCALL DestroyInstance(int id, void *ptr) {
   switch (id) {
   case ID_LEVEL_0000:
     delete ((LevelScript_0000 *)ptr);
+    break;
   case ID_TRIGGER_0004:
     delete ((TriggerScript_0004 *)ptr);
     break;

--- a/scripts/RudeAwakening.cpp
+++ b/scripts/RudeAwakening.cpp
@@ -548,6 +548,7 @@ void STDCALL DestroyInstance(int id, void *ptr) {
   switch (id) {
   case ID_LEVEL_0000:
     delete ((LevelScript_0000 *)ptr);
+    break;
   case ID_CUSTOM_OBJECT_1017:
     delete ((CustomObjectScript_1017 *)ptr);
     break;

--- a/scripts/TrainingMission.cpp
+++ b/scripts/TrainingMission.cpp
@@ -1104,6 +1104,7 @@ void STDCALL DestroyInstance(int id, void *ptr) {
   switch (id) {
   case ID_LEVEL_0000:
     delete ((LevelScript_0000 *)ptr);
+    break;
   case ID_CUSTOM_OBJECT_300D:
     delete ((CustomObjectScript_300D *)ptr);
     break;

--- a/scripts/level1.cpp
+++ b/scripts/level1.cpp
@@ -861,6 +861,7 @@ void STDCALL DestroyInstance(int id, void *ptr) {
   switch (id) {
   case ID_LEVEL_0000:
     delete ((LevelScript_0000 *)ptr);
+    break;
   case ID_CUSTOM_OBJECT_3855:
     delete ((CustomObjectScript_3855 *)ptr);
     break;

--- a/scripts/level10.cpp
+++ b/scripts/level10.cpp
@@ -2026,6 +2026,7 @@ void STDCALL DestroyInstance(int id, void *ptr) {
   switch (id) {
   case ID_LEVEL_0000:
     delete ((LevelScript_0000 *)ptr);
+    break;
   case ID_CUSTOM_OBJECT_2042:
     delete ((CustomObjectScript_2042 *)ptr);
     break;

--- a/scripts/level11.cpp
+++ b/scripts/level11.cpp
@@ -2612,6 +2612,7 @@ void STDCALL DestroyInstance(int id, void *ptr) {
   switch (id) {
   case ID_LEVEL_0000:
     delete ((LevelScript_0000 *)ptr);
+    break;
   case ID_CUSTOM_OBJECT_0985:
     delete ((CustomObjectScript_0985 *)ptr);
     break;

--- a/scripts/level13.cpp
+++ b/scripts/level13.cpp
@@ -2081,6 +2081,7 @@ void STDCALL DestroyInstance(int id, void *ptr) {
   switch (id) {
   case ID_LEVEL_0000:
     delete ((LevelScript_0000 *)ptr);
+    break;
   case ID_CUSTOM_OBJECT_1074:
     delete ((CustomObjectScript_1074 *)ptr);
     break;

--- a/scripts/level14.cpp
+++ b/scripts/level14.cpp
@@ -1450,6 +1450,7 @@ void STDCALL DestroyInstance(int id, void *ptr) {
   switch (id) {
   case ID_LEVEL_0000:
     delete ((LevelScript_0000 *)ptr);
+    break;
   case ID_CUSTOM_OBJECT_10B8:
     delete ((CustomObjectScript_10B8 *)ptr);
     break;

--- a/scripts/level17.cpp
+++ b/scripts/level17.cpp
@@ -2328,6 +2328,7 @@ void STDCALL DestroyInstance(int id, void *ptr) {
   switch (id) {
   case ID_LEVEL_0000:
     delete ((LevelScript_0000 *)ptr);
+    break;
   case ID_CUSTOM_OBJECT_0821:
     delete ((CustomObjectScript_0821 *)ptr);
     break;

--- a/scripts/level2.cpp
+++ b/scripts/level2.cpp
@@ -1711,6 +1711,7 @@ void STDCALL DestroyInstance(int id, void *ptr) {
   switch (id) {
   case ID_LEVEL_0000:
     delete ((LevelScript_0000 *)ptr);
+    break;
   case ID_CUSTOM_OBJECT_082D:
     delete ((CustomObjectScript_082D *)ptr);
     break;

--- a/scripts/level3.cpp
+++ b/scripts/level3.cpp
@@ -1555,6 +1555,7 @@ void STDCALL DestroyInstance(int id, void *ptr) {
   switch (id) {
   case ID_LEVEL_0000:
     delete ((LevelScript_0000 *)ptr);
+    break;
   case ID_CUSTOM_OBJECT_2109:
     delete ((CustomObjectScript_2109 *)ptr);
     break;

--- a/scripts/level4.cpp
+++ b/scripts/level4.cpp
@@ -816,6 +816,7 @@ void STDCALL DestroyInstance(int id, void *ptr) {
   switch (id) {
   case ID_LEVEL_0000:
     delete ((LevelScript_0000 *)ptr);
+    break;
   case ID_CUSTOM_OBJECT_08B3:
     delete ((CustomObjectScript_08B3 *)ptr);
     break;

--- a/scripts/level5.cpp
+++ b/scripts/level5.cpp
@@ -1187,6 +1187,7 @@ void STDCALL DestroyInstance(int id, void *ptr) {
   switch (id) {
   case ID_LEVEL_0000:
     delete ((LevelScript_0000 *)ptr);
+    break;
   case ID_CUSTOM_OBJECT_200D:
     delete ((CustomObjectScript_200D *)ptr);
     break;

--- a/scripts/level7.cpp
+++ b/scripts/level7.cpp
@@ -1436,6 +1436,7 @@ void STDCALL DestroyInstance(int id, void *ptr) {
   switch (id) {
   case ID_LEVEL_0000:
     delete ((LevelScript_0000 *)ptr);
+    break;
   case ID_CUSTOM_OBJECT_1097:
     delete ((CustomObjectScript_1097 *)ptr);
     break;

--- a/scripts/level8.cpp
+++ b/scripts/level8.cpp
@@ -1498,6 +1498,7 @@ void STDCALL DestroyInstance(int id, void *ptr) {
   switch (id) {
   case ID_LEVEL_0000:
     delete ((LevelScript_0000 *)ptr);
+    break;
   case ID_CUSTOM_OBJECT_10FD:
     delete ((CustomObjectScript_10FD *)ptr);
     break;

--- a/scripts/levelS2.cpp
+++ b/scripts/levelS2.cpp
@@ -2366,6 +2366,7 @@ void STDCALL DestroyInstance(int id, void *ptr) {
   switch (id) {
   case ID_LEVEL_0000:
     delete ((LevelScript_0000 *)ptr);
+    break;
   case ID_CUSTOM_OBJECT_0821:
     delete ((CustomObjectScript_0821 *)ptr);
     break;

--- a/scripts/merc5.cpp
+++ b/scripts/merc5.cpp
@@ -1663,6 +1663,7 @@ void STDCALL DestroyInstance(int id, void *ptr) {
   switch (id) {
   case ID_LEVEL_0000:
     delete ((LevelScript_0000 *)ptr);
+    break;
   case ID_CUSTOM_OBJECT_11C4:
     delete ((CustomObjectScript_11C4 *)ptr);
     break;

--- a/scripts/myPowerHouse.cpp
+++ b/scripts/myPowerHouse.cpp
@@ -445,6 +445,7 @@ void STDCALL DestroyInstance(int id, void *ptr) {
   switch (id) {
   case ID_LEVEL_0000:
     delete ((LevelScript_0000 *)ptr);
+    break;
   case ID_CUSTOM_OBJECT_0827:
     delete ((CustomObjectScript_0827 *)ptr);
     break;

--- a/scripts/orbital.cpp
+++ b/scripts/orbital.cpp
@@ -653,6 +653,7 @@ void STDCALL DestroyInstance(int id, void *ptr) {
   switch (id) {
   case ID_LEVEL_0000:
     delete ((LevelScript_0000 *)ptr);
+    break;
   case ID_CUSTOM_OBJECT_0903:
     delete ((CustomObjectScript_0903 *)ptr);
     break;

--- a/sndlib/hlsoundlib.cpp
+++ b/sndlib/hlsoundlib.cpp
@@ -870,7 +870,7 @@ bool hlsSystem::ComputePlayInfo(int sound_obj_index, vector *virtual_pos, vector
   vector sound_pos;
   m_sound_objects[sound_obj_index].play_info.sample_skip_interval = 0;
   vector dir_to_sound;
-  float dist;
+  float dist = 0;
   if (m_master_volume <= 0.0)
     return false;
 


### PR DESCRIPTION
Most of the warnings were caused by uninitialized values. 
Some were in plug-ins that didn't have a break in a switch, causing the memory to be deleted twice.